### PR TITLE
Integrate function trace inspector into session replay

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,24 +20,24 @@ function SessionReplayRoute() {
     const sid = useSessionIdFromUrl();
     if (!sid) {
         return (
-            <div className="min-h-screen bg-slate-950 text-slate-100">
+            <div className="min-h-screen bg-slate-900 text-slate-100">
                 <div className="relative h-full overflow-hidden">
                     <div className="pointer-events-none absolute inset-0">
-                        <div className="absolute -top-28 -left-28 h-72 w-72 rounded-full bg-sky-500/20 blur-3xl" />
-                        <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-fuchsia-500/10 blur-3xl" />
+                        <div className="absolute -top-28 -left-28 h-72 w-72 rounded-full bg-sky-400/30 blur-3xl" />
+                        <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-fuchsia-400/20 blur-3xl" />
                     </div>
                     <div className="relative flex h-full flex-col items-center justify-center px-8 py-16 text-center">
                         <div className="max-w-xl space-y-6">
                             <div className="space-y-2">
-                                <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Replay console</h1>
-                                <p className="text-sm text-slate-400 sm:text-base">
-                                    Add <code className="rounded bg-slate-900 px-1.5 py-0.5 text-slate-200">?sessionId=YOUR_SESSION_ID</code> to the URL
-                                    or use the hash form <code className="rounded bg-slate-900 px-1.5 py-0.5 text-slate-200">#/s/YOUR_SESSION_ID</code> to load a session.
+                                <h1 className="text-3xl font-semibold tracking-tight text-slate-50 sm:text-4xl">Replay console</h1>
+                                <p className="text-sm text-slate-300 sm:text-base">
+                                    Add <code className="rounded bg-slate-800 px-1.5 py-0.5 text-slate-100">?sessionId=YOUR_SESSION_ID</code> to the URL
+                                    or use the hash form <code className="rounded bg-slate-800 px-1.5 py-0.5 text-slate-100">#/s/YOUR_SESSION_ID</code> to load a session.
                                 </p>
                             </div>
-                            <div className="rounded-2xl border border-slate-800/60 bg-slate-900/70 px-6 py-5 text-left text-sm text-slate-300 shadow-xl backdrop-blur">
-                                <p className="font-semibold text-slate-200">Tip</p>
-                                <p className="mt-2 text-slate-400">
+                            <div className="rounded-2xl border border-slate-700/60 bg-slate-900/60 px-6 py-5 text-left text-sm text-slate-200 shadow-xl backdrop-blur">
+                                <p className="font-semibold text-slate-100">Tip</p>
+                                <p className="mt-2 text-slate-300">
                                     Once a session loads you&apos;ll be able to inspect the replay, backend timeline, and the captured function trace all in one place.
                                 </p>
                             </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,27 +20,22 @@ function SessionReplayRoute() {
     const sid = useSessionIdFromUrl();
     if (!sid) {
         return (
-            <div className="min-h-screen bg-slate-900 text-slate-100">
-                <div className="relative h-full overflow-hidden">
-                    <div className="pointer-events-none absolute inset-0">
-                        <div className="absolute -top-28 -left-28 h-72 w-72 rounded-full bg-sky-400/30 blur-3xl" />
-                        <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-fuchsia-400/20 blur-3xl" />
-                    </div>
-                    <div className="relative flex h-full flex-col items-center justify-center px-8 py-16 text-center">
-                        <div className="max-w-xl space-y-6">
-                            <div className="space-y-2">
-                                <h1 className="text-3xl font-semibold tracking-tight text-slate-50 sm:text-4xl">Replay console</h1>
-                                <p className="text-sm text-slate-300 sm:text-base">
-                                    Add <code className="rounded bg-slate-800 px-1.5 py-0.5 text-slate-100">?sessionId=YOUR_SESSION_ID</code> to the URL
-                                    or use the hash form <code className="rounded bg-slate-800 px-1.5 py-0.5 text-slate-100">#/s/YOUR_SESSION_ID</code> to load a session.
-                                </p>
-                            </div>
-                            <div className="rounded-2xl border border-slate-700/60 bg-slate-900/60 px-6 py-5 text-left text-sm text-slate-200 shadow-xl backdrop-blur">
-                                <p className="font-semibold text-slate-100">Tip</p>
-                                <p className="mt-2 text-slate-300">
-                                    Once a session loads you&apos;ll be able to inspect the replay, backend timeline, and the captured function trace all in one place.
-                                </p>
-                            </div>
+            <div className="min-h-screen bg-slate-50 text-slate-900">
+                <div className="flex min-h-screen flex-col items-center justify-center px-6 py-16">
+                    <div className="w-full max-w-lg space-y-6 rounded-3xl border border-slate-200 bg-white p-10 shadow-xl shadow-slate-200/60">
+                        <div className="space-y-3 text-left">
+                            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-slate-500">Replay console</p>
+                            <h1 className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">Load a session to get started</h1>
+                            <p className="text-sm leading-6 text-slate-600 sm:text-base">
+                                Append <code className="rounded bg-slate-100 px-1.5 py-0.5 text-slate-900">?sessionId=YOUR_SESSION_ID</code> to the URL or use the hash form
+                                <code className="ml-1 rounded bg-slate-100 px-1.5 py-0.5 text-slate-900">#/s/YOUR_SESSION_ID</code> to open a captured session replay.
+                            </p>
+                        </div>
+                        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-6 py-5 text-left text-sm text-slate-600">
+                            <p className="font-semibold text-slate-900">Why you&apos;ll like it</p>
+                            <p className="mt-2 text-slate-600">
+                                The viewer combines the rrweb recording, backend timeline, and any instrumented function traces so you can debug end-to-end without leaving the page.
+                            </p>
                         </div>
                     </div>
                 </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,25 +20,24 @@ function SessionReplayRoute() {
     const sid = useSessionIdFromUrl();
     if (!sid) {
         return (
-            <div className="min-h-screen bg-slate-50 text-slate-900">
-                <div className="flex min-h-screen flex-col items-center justify-center px-6 py-16">
-                    <div className="w-full max-w-lg space-y-6 rounded-3xl border border-slate-200 bg-white p-10 shadow-xl shadow-slate-200/60">
-                        <div className="space-y-3 text-left">
-                            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-slate-500">Replay console</p>
-                            <h1 className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">Load a session to get started</h1>
-                            <p className="text-sm leading-6 text-slate-600 sm:text-base">
-                                Append <code className="rounded bg-slate-100 px-1.5 py-0.5 text-slate-900">?sessionId=YOUR_SESSION_ID</code> to the URL or use the hash form
-                                <code className="ml-1 rounded bg-slate-100 px-1.5 py-0.5 text-slate-900">#/s/YOUR_SESSION_ID</code> to open a captured session replay.
-                            </p>
-                        </div>
-                        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-6 py-5 text-left text-sm text-slate-600">
-                            <p className="font-semibold text-slate-900">Why you&apos;ll like it</p>
-                            <p className="mt-2 text-slate-600">
-                                The viewer combines the rrweb recording, backend timeline, and any instrumented function traces so you can debug end-to-end without leaving the page.
-                            </p>
-                        </div>
+            <div className="flex min-h-screen flex-col bg-slate-100 text-slate-900">
+                <header className="border-b border-slate-200 bg-white px-8 py-5">
+                    <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.4em] text-slate-500">Replay console</p>
+                        <h1 className="text-2xl font-semibold tracking-tight text-slate-900">Load a session to get started</h1>
                     </div>
-                </div>
+                </header>
+                <main className="flex flex-1 items-center justify-center px-8 py-16">
+                    <div className="w-full max-w-xl border border-slate-200 bg-white px-6 py-8 text-sm text-slate-600">
+                        <p>
+                            Append <code className="bg-slate-200 px-2 py-1 text-xs text-slate-900">?sessionId=YOUR_SESSION_ID</code> to the URL or use
+                            <code className="ml-2 bg-slate-200 px-2 py-1 text-xs text-slate-900">#/s/YOUR_SESSION_ID</code> to open a captured session replay.
+                        </p>
+                        <p className="mt-4">
+                            The viewer combines the rrweb recording, backend timeline, and any instrumented function traces so you can debug end-to-end without leaving the page.
+                        </p>
+                    </div>
+                </main>
             </div>
         );
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 // src/App.jsx
 import React from "react";
-import { Routes, Route, Link, Navigate, useSearchParams, useLocation } from "react-router-dom";
+import { Routes, Route, Navigate, useSearchParams, useLocation } from "react-router-dom";
 import SessionReplay from "./pages/SessionReplay";
 import FunctionTracePage from "./pages/FunctionTracePage";
 
@@ -20,16 +20,30 @@ function SessionReplayRoute() {
     const sid = useSessionIdFromUrl();
     if (!sid) {
         return (
-            <div style={{ padding: 24 }}>
-                <h2>Replay</h2>
-                <p>
-                    Add <code>?sessionId=YOUR_SESSION_ID</code> to the URL, or use hash:&nbsp;
-                    <code>#/s/YOUR_SESSION_ID</code>
-                </p>
-                <p>
-                    Or jump to the{" "}
-                    <Link to="/trace">Function Trace Viewer</Link>.
-                </p>
+            <div className="min-h-screen bg-slate-950 text-slate-100">
+                <div className="relative h-full overflow-hidden">
+                    <div className="pointer-events-none absolute inset-0">
+                        <div className="absolute -top-28 -left-28 h-72 w-72 rounded-full bg-sky-500/20 blur-3xl" />
+                        <div className="absolute bottom-0 right-0 h-80 w-80 rounded-full bg-fuchsia-500/10 blur-3xl" />
+                    </div>
+                    <div className="relative flex h-full flex-col items-center justify-center px-8 py-16 text-center">
+                        <div className="max-w-xl space-y-6">
+                            <div className="space-y-2">
+                                <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Replay console</h1>
+                                <p className="text-sm text-slate-400 sm:text-base">
+                                    Add <code className="rounded bg-slate-900 px-1.5 py-0.5 text-slate-200">?sessionId=YOUR_SESSION_ID</code> to the URL
+                                    or use the hash form <code className="rounded bg-slate-900 px-1.5 py-0.5 text-slate-200">#/s/YOUR_SESSION_ID</code> to load a session.
+                                </p>
+                            </div>
+                            <div className="rounded-2xl border border-slate-800/60 bg-slate-900/70 px-6 py-5 text-left text-sm text-slate-300 shadow-xl backdrop-blur">
+                                <p className="font-semibold text-slate-200">Tip</p>
+                                <p className="mt-2 text-slate-400">
+                                    Once a session loads you&apos;ll be able to inspect the replay, backend timeline, and the captured function trace all in one place.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         );
     }
@@ -38,25 +52,15 @@ function SessionReplayRoute() {
 
 export default function App() {
     return (
-        <div className="min-h-screen flex flex-col">
-            {/* simple top nav */}
-            <header className="flex items-center gap-4 p-3 border-b">
-                <Link to="/" className="font-semibold">Session Replay</Link>
-                <Link to="/trace" className="text-gray-600 hover:text-black">Function Trace</Link>
-            </header>
+        <Routes>
+            {/* MAIN route: SessionReplay */}
+            <Route path="/" element={<SessionReplayRoute />} />
 
-            <main className="flex-1">
-                <Routes>
-                    {/* MAIN route: SessionReplay */}
-                    <Route path="/" element={<SessionReplayRoute />} />
+            {/* Function Trace Viewer route */}
+            <Route path="/trace" element={<FunctionTracePage />} />
 
-                    {/* Function Trace Viewer route */}
-                    <Route path="/trace" element={<FunctionTracePage />} />
-
-                    {/* Optional: redirect unknown paths to home */}
-                    <Route path="*" element={<Navigate to="/" replace />} />
-                </Routes>
-            </main>
-        </div>
+            {/* Optional: redirect unknown paths to home */}
+            <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
     );
 }

--- a/src/components/FunctionTraceViewer.css
+++ b/src/components/FunctionTraceViewer.css
@@ -1,25 +1,25 @@
 .trace-viewer {
-  --trace-bg: #07090c;
-  --trace-card-bg: rgba(17, 22, 30, 0.9);
-  --trace-card-hover: rgba(26, 32, 43, 0.95);
-  --trace-border: #1e2a39;
-  --trace-border-strong: #314052;
-  --trace-fg: #e5ecff;
-  --trace-muted: rgba(201, 214, 255, 0.6);
-  --trace-muted-strong: rgba(221, 229, 255, 0.85);
-  --trace-accent: #5ab0ff;
-  --trace-keyword: #8f9eff;
+  --trace-bg: #0b1424;
+  --trace-card-bg: rgba(18, 26, 40, 0.92);
+  --trace-card-hover: rgba(28, 38, 56, 0.96);
+  --trace-border: #264163;
+  --trace-border-strong: #3c5a82;
+  --trace-fg: #f1f5ff;
+  --trace-muted: rgba(214, 227, 255, 0.72);
+  --trace-muted-strong: rgba(232, 239, 255, 0.9);
+  --trace-accent: #60a5fa;
+  --trace-keyword: #98b7ff;
   --trace-error: #ff6b81;
-  --trace-chip-bg: rgba(59, 76, 102, 0.3);
-  --trace-code-bg: rgba(10, 14, 20, 0.9);
+  --trace-chip-bg: rgba(92, 123, 180, 0.32);
+  --trace-code-bg: rgba(18, 26, 42, 0.9);
   --trace-mono: "JetBrains Mono", "Fira Code", "Menlo", "Consolas", monospace;
-  background: radial-gradient(circle at top left, rgba(43, 101, 255, 0.16), transparent 55%),
-    radial-gradient(circle at bottom right, rgba(255, 94, 163, 0.18), transparent 45%),
+  background: radial-gradient(circle at top left, rgba(96, 165, 250, 0.22), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(236, 72, 153, 0.24), transparent 45%),
     var(--trace-bg);
   color: var(--trace-fg);
   border-radius: 20px;
   padding: 24px 28px 28px;
-  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 18px 60px rgba(15, 23, 42, 0.45);
   display: flex;
   flex-direction: column;
   gap: 20px;

--- a/src/components/FunctionTraceViewer.css
+++ b/src/components/FunctionTraceViewer.css
@@ -1,24 +1,22 @@
 .trace-viewer {
-  --trace-bg: #f8fafc;
+  --trace-bg: #f3f4f6;
   --trace-card-bg: #ffffff;
-  --trace-card-hover: #f1f5f9;
-  --trace-border: #d7e0ef;
+  --trace-card-hover: #e2e8f0;
+  --trace-border: #cbd5e1;
   --trace-border-strong: #94a3b8;
   --trace-fg: #0f172a;
-  --trace-muted: #64748b;
-  --trace-muted-strong: #475569;
-  --trace-accent: #0f6eea;
+  --trace-muted: #475569;
+  --trace-muted-strong: #1f2937;
+  --trace-accent: #1d4ed8;
   --trace-keyword: #1d4ed8;
   --trace-error: #dc2626;
   --trace-chip-bg: rgba(148, 163, 184, 0.15);
-  --trace-code-bg: #f1f5f9;
+  --trace-code-bg: #e2e8f0;
   --trace-mono: "JetBrains Mono", "Fira Code", "Menlo", "Consolas", monospace;
   background: var(--trace-bg);
   color: var(--trace-fg);
-  border-radius: 20px;
   border: 1px solid var(--trace-border);
   padding: 24px 28px 28px;
-  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.08);
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -77,7 +75,6 @@
   align-items: center;
   gap: 8px;
   padding: 6px 12px;
-  border-radius: 12px;
   background: #ffffff;
   border: 1px solid var(--trace-border);
   color: var(--trace-muted-strong);
@@ -120,7 +117,6 @@
 
 .view-toggle {
   display: inline-flex;
-  border-radius: 999px;
   padding: 4px;
   border: 1px solid var(--trace-border);
   background: #ffffff;
@@ -129,7 +125,6 @@
 
 .view-toggle button {
   border: none;
-  border-radius: 999px;
   padding: 8px 16px;
   font-size: 13px;
   font-weight: 500;
@@ -180,21 +175,17 @@
 .trace-card {
   background: var(--trace-card-bg);
   border: 1px solid var(--trace-border);
-  border-radius: 16px;
   padding: 14px 18px;
-  transition: background 0.25s ease, border-color 0.25s ease, transform 0.25s ease;
-  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+  transition: background 0.25s ease, border-color 0.25s ease;
 }
 
 .trace-card:hover {
   border-color: var(--trace-border-strong);
   background: var(--trace-card-hover);
-  transform: translateY(-1px);
 }
 
 .trace-card.is-error {
   border-color: var(--trace-error);
-  box-shadow: 0 0 0 1px rgba(220, 38, 38, 0.18), 0 16px 32px rgba(220, 38, 38, 0.12);
 }
 
 .trace-card.is-event {
@@ -213,7 +204,6 @@
 .tree-toggle {
   width: 28px;
   height: 28px;
-  border-radius: 50%;
   border: 1px solid var(--trace-border);
   background: #ffffff;
   color: var(--trace-muted-strong);
@@ -279,7 +269,6 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   padding: 2px 6px;
-  border-radius: 999px;
   border: 1px solid rgba(148, 163, 184, 0.5);
   background: rgba(148, 163, 184, 0.15);
   color: var(--trace-muted-strong);
@@ -303,7 +292,6 @@
   text-transform: uppercase;
   letter-spacing: 0.06em;
   padding: 2px 6px;
-  border-radius: 999px;
   border: 1px solid rgba(148, 163, 184, 0.5);
   background: rgba(148, 163, 184, 0.12);
 }
@@ -321,7 +309,6 @@
   align-items: center;
   gap: 6px;
   padding: 3px 8px;
-  border-radius: 999px;
   border: 1px solid var(--trace-border);
   background: var(--trace-chip-bg);
   color: var(--trace-muted-strong);
@@ -337,7 +324,6 @@
 .trace-bar {
   width: 100%;
   height: 6px;
-  border-radius: 999px;
   background: rgba(148, 163, 184, 0.25);
   border: 1px solid rgba(148, 163, 184, 0.35);
   overflow: hidden;
@@ -357,7 +343,6 @@
 
 .detail-toggle {
   border: 1px solid var(--trace-border);
-  border-radius: 10px;
   padding: 6px 12px;
   font-size: 12px;
   background: #ffffff;
@@ -391,7 +376,6 @@
 .trace-detail-block pre {
   margin: 0;
   background: var(--trace-code-bg);
-  border-radius: 12px;
   padding: 12px;
   border: 1px solid var(--trace-border);
   font-size: 12px;
@@ -422,12 +406,10 @@
 .trace-graph-wrapper {
   position: relative;
   flex: 1;
-  border-radius: 18px;
   border: 1px solid var(--trace-border);
   background: #ffffff;
   overflow: hidden;
   min-height: 420px;
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
 }
 
 .trace-graph-flow,
@@ -467,7 +449,6 @@
   flex-direction: column;
   gap: 8px;
   background: #ffffff;
-  border-radius: 16px;
   border: 1px solid var(--trace-border);
   padding: 14px 16px;
   box-shadow: 0 12px 32px rgba(15, 23, 42, 0.12);
@@ -531,7 +512,6 @@
   letter-spacing: 0.1em;
   align-self: flex-start;
   padding: 2px 6px;
-  border-radius: 999px;
   border: 1px solid rgba(148, 163, 184, 0.5);
   background: rgba(148, 163, 184, 0.15);
 }
@@ -539,28 +519,21 @@
 .trace-graph-wrapper .react-flow__panel {
   background: rgba(248, 250, 252, 0.95);
   border: 1px solid var(--trace-border);
-  border-radius: 14px;
-  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.12);
   overflow: hidden;
 }
 
 .trace-graph-wrapper .react-flow__controls-button {
   width: 34px;
   height: 34px;
-  border-radius: 50%;
   background: #ffffff;
   border: 1px solid var(--trace-border);
   color: var(--trace-fg);
-  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  transition: background 0.2s ease, border-color 0.2s ease;
 }
 
 .trace-graph-wrapper .react-flow__controls-button:hover:not(:disabled) {
   background: var(--trace-card-hover);
   border-color: var(--trace-border-strong);
-}
-
-.trace-graph-wrapper .react-flow__controls-button:active:not(:disabled) {
-  transform: scale(0.95);
 }
 
 .trace-graph-wrapper .react-flow__controls-button:disabled {
@@ -570,7 +543,6 @@
 .trace-graph-wrapper .react-flow__minimap {
   background: rgba(241, 245, 249, 0.9);
   border: 1px solid var(--trace-border);
-  border-radius: 12px;
 }
 
 .trace-graph-wrapper .react-flow__minimap-mask {
@@ -618,7 +590,6 @@
 
 .react-flow__node.is-focused .graph-node-card,
 .graph-node-card.is-focused {
-  box-shadow: 0 0 0 3px rgba(250, 204, 21, 0.6);
   outline: none;
 }
 
@@ -632,7 +603,6 @@
   display: inline-block;
   padding: 2px 6px;
   margin-left: 6px;
-  border-radius: 8px;
   font-size: 11px;
   opacity: 0.8;
   border: 1px solid currentColor;

--- a/src/components/FunctionTraceViewer.css
+++ b/src/components/FunctionTraceViewer.css
@@ -26,6 +26,19 @@
   min-height: 70vh;
 }
 
+.trace-viewer.is-embedded {
+  min-height: 0;
+  height: 100%;
+}
+
+.trace-viewer.is-embedded .trace-content {
+  min-height: 0;
+}
+
+.trace-viewer.is-embedded .trace-tree-scroll {
+  max-height: none;
+}
+
 .trace-header {
   display: flex;
   flex-wrap: wrap;

--- a/src/components/FunctionTraceViewer.css
+++ b/src/components/FunctionTraceViewer.css
@@ -1,29 +1,28 @@
 .trace-viewer {
-  --trace-bg: #0b1424;
-  --trace-card-bg: rgba(18, 26, 40, 0.92);
-  --trace-card-hover: rgba(28, 38, 56, 0.96);
-  --trace-border: #264163;
-  --trace-border-strong: #3c5a82;
-  --trace-fg: #f1f5ff;
-  --trace-muted: rgba(214, 227, 255, 0.72);
-  --trace-muted-strong: rgba(232, 239, 255, 0.9);
-  --trace-accent: #60a5fa;
-  --trace-keyword: #98b7ff;
-  --trace-error: #ff6b81;
-  --trace-chip-bg: rgba(92, 123, 180, 0.32);
-  --trace-code-bg: rgba(18, 26, 42, 0.9);
+  --trace-bg: #f8fafc;
+  --trace-card-bg: #ffffff;
+  --trace-card-hover: #f1f5f9;
+  --trace-border: #d7e0ef;
+  --trace-border-strong: #94a3b8;
+  --trace-fg: #0f172a;
+  --trace-muted: #64748b;
+  --trace-muted-strong: #475569;
+  --trace-accent: #0f6eea;
+  --trace-keyword: #1d4ed8;
+  --trace-error: #dc2626;
+  --trace-chip-bg: rgba(148, 163, 184, 0.15);
+  --trace-code-bg: #f1f5f9;
   --trace-mono: "JetBrains Mono", "Fira Code", "Menlo", "Consolas", monospace;
-  background: radial-gradient(circle at top left, rgba(96, 165, 250, 0.22), transparent 55%),
-    radial-gradient(circle at bottom right, rgba(236, 72, 153, 0.24), transparent 45%),
-    var(--trace-bg);
+  background: var(--trace-bg);
   color: var(--trace-fg);
   border-radius: 20px;
+  border: 1px solid var(--trace-border);
   padding: 24px 28px 28px;
-  box-shadow: 0 18px 60px rgba(15, 23, 42, 0.45);
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.08);
   display: flex;
   flex-direction: column;
   gap: 20px;
-  min-height: 70vh;
+  min-height: 60vh;
 }
 
 .trace-viewer.is-embedded {
@@ -58,6 +57,7 @@
   font-size: 20px;
   font-weight: 600;
   letter-spacing: 0.01em;
+  color: var(--trace-fg);
 }
 
 .trace-subhead {
@@ -78,7 +78,7 @@
   gap: 8px;
   padding: 6px 12px;
   border-radius: 12px;
-  background: rgba(12, 16, 24, 0.85);
+  background: #ffffff;
   border: 1px solid var(--trace-border);
   color: var(--trace-muted-strong);
   font-size: 13px;
@@ -122,9 +122,8 @@
   display: inline-flex;
   border-radius: 999px;
   padding: 4px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(12, 16, 24, 0.75);
-  backdrop-filter: blur(8px);
+  border: 1px solid var(--trace-border);
+  background: #ffffff;
   gap: 4px;
 }
 
@@ -142,12 +141,13 @@
 
 .view-toggle button:hover {
   color: var(--trace-fg);
+  background: var(--trace-card-hover);
 }
 
 .view-toggle button.is-active {
-  background: linear-gradient(120deg, rgba(90, 176, 255, 0.22), rgba(143, 158, 255, 0.25));
-  color: var(--trace-fg);
-  box-shadow: 0 6px 16px rgba(90, 176, 255, 0.25);
+  background: var(--trace-accent);
+  color: #ffffff;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.14);
 }
 
 .trace-content {
@@ -183,7 +183,7 @@
   border-radius: 16px;
   padding: 14px 18px;
   transition: background 0.25s ease, border-color 0.25s ease, transform 0.25s ease;
-  backdrop-filter: blur(12px);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
 }
 
 .trace-card:hover {
@@ -194,7 +194,7 @@
 
 .trace-card.is-error {
   border-color: var(--trace-error);
-  box-shadow: 0 0 0 1px rgba(255, 107, 129, 0.18), 0 16px 40px rgba(255, 107, 129, 0.14);
+  box-shadow: 0 0 0 1px rgba(220, 38, 38, 0.18), 0 16px 32px rgba(220, 38, 38, 0.12);
 }
 
 .trace-card.is-event {
@@ -215,7 +215,7 @@
   height: 28px;
   border-radius: 50%;
   border: 1px solid var(--trace-border);
-  background: rgba(9, 12, 18, 0.65);
+  background: #ffffff;
   color: var(--trace-muted-strong);
   display: inline-flex;
   align-items: center;
@@ -226,7 +226,7 @@
 }
 
 .tree-toggle:hover {
-  background: rgba(24, 33, 48, 0.95);
+  background: var(--trace-card-hover);
   border-color: var(--trace-border-strong);
   color: var(--trace-fg);
 }
@@ -234,8 +234,8 @@
 .tree-toggle.placeholder {
   pointer-events: none;
   background: transparent;
-  border: 1px dashed rgba(255, 255, 255, 0.08);
-  color: rgba(255, 255, 255, 0.2);
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  color: rgba(148, 163, 184, 0.6);
 }
 
 .tree-toggle span {
@@ -258,6 +258,7 @@
   align-items: baseline;
   gap: 8px;
   line-height: 1.5;
+  color: var(--trace-fg);
 }
 
 .trace-signature .keyword {
@@ -279,9 +280,9 @@
   letter-spacing: 0.08em;
   padding: 2px 6px;
   border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  background: rgba(90, 176, 255, 0.12);
-  color: var(--trace-accent);
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  background: rgba(148, 163, 184, 0.15);
+  color: var(--trace-muted-strong);
 }
 
 .trace-signature .arrow {
@@ -303,8 +304,8 @@
   letter-spacing: 0.06em;
   padding: 2px 6px;
   border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  background: rgba(148, 163, 184, 0.12);
 }
 
 .trace-meta {
@@ -337,14 +338,14 @@
   width: 100%;
   height: 6px;
   border-radius: 999px;
-  background: rgba(86, 120, 171, 0.3);
-  border: 1px solid rgba(86, 120, 171, 0.5);
+  background: rgba(148, 163, 184, 0.25);
+  border: 1px solid rgba(148, 163, 184, 0.35);
   overflow: hidden;
 }
 
 .trace-bar-fill {
   height: 100%;
-  background: linear-gradient(90deg, rgba(90, 176, 255, 0.8), rgba(143, 158, 255, 0.85));
+  background: var(--trace-accent);
   transform-origin: left;
   transition: transform 0.35s ease;
 }
@@ -359,14 +360,14 @@
   border-radius: 10px;
   padding: 6px 12px;
   font-size: 12px;
-  background: rgba(18, 24, 34, 0.8);
+  background: #ffffff;
   color: var(--trace-muted-strong);
   cursor: pointer;
   transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
 }
 
 .detail-toggle:hover {
-  background: rgba(38, 48, 66, 0.95);
+  background: var(--trace-card-hover);
   color: var(--trace-fg);
   border-color: var(--trace-border-strong);
 }
@@ -374,7 +375,7 @@
 .trace-details {
   display: grid;
   gap: 12px;
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  border-top: 1px solid rgba(148, 163, 184, 0.25);
   padding-top: 10px;
 }
 
@@ -399,13 +400,14 @@
   word-break: break-word;
   max-height: 260px;
   overflow: auto;
+  color: var(--trace-muted-strong);
 }
 
 .trace-children {
   margin-top: 12px;
   margin-left: 32px;
   padding-left: 18px;
-  border-left: 1px solid rgba(255, 255, 255, 0.06);
+  border-left: 1px solid rgba(148, 163, 184, 0.35);
   display: grid;
   gap: 12px;
 }
@@ -421,11 +423,11 @@
   position: relative;
   flex: 1;
   border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  background: rgba(12, 16, 24, 0.75);
+  border: 1px solid var(--trace-border);
+  background: #ffffff;
   overflow: hidden;
   min-height: 420px;
-  box-shadow: inset 0 0 0 1px rgba(90, 176, 255, 0.06);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
 }
 
 .trace-graph-flow,
@@ -443,20 +445,20 @@
 }
 
 .trace-graph-wrapper .react-flow__edge-path {
-  stroke: rgba(129, 176, 255, 0.55);
+  stroke: rgba(59, 130, 246, 0.6);
   stroke-width: 1.8;
   stroke-linecap: round;
 }
 
 .trace-graph-wrapper .react-flow__edge-path:hover {
-  stroke: rgba(129, 176, 255, 0.85);
+  stroke: rgba(59, 130, 246, 0.85);
 }
 
 .trace-graph-wrapper .react-flow__node-traceNode {
   padding: 0;
   background: transparent;
   border: none;
-  filter: drop-shadow(0 18px 42px rgba(3, 7, 16, 0.6));
+  filter: drop-shadow(0 14px 28px rgba(15, 23, 42, 0.18));
 }
 
 .graph-node-card {
@@ -464,20 +466,19 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  background: rgba(13, 19, 30, 0.95);
+  background: #ffffff;
   border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--trace-border);
   padding: 14px 16px;
-  box-shadow: 0 12px 30px rgba(4, 8, 18, 0.55);
-  backdrop-filter: blur(10px);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.12);
   font-family: var(--trace-mono);
   font-size: 12px;
   color: var(--trace-muted-strong);
 }
 
 .graph-node-card.is-error {
-  border-color: rgba(255, 107, 129, 0.6);
-  box-shadow: 0 0 0 1px rgba(255, 107, 129, 0.25), 0 18px 38px rgba(255, 107, 129, 0.2);
+  border-color: var(--trace-error);
+  box-shadow: 0 0 0 1px rgba(220, 38, 38, 0.25), 0 16px 32px rgba(220, 38, 38, 0.16);
 }
 
 .graph-node-card.is-event {
@@ -507,6 +508,7 @@
   flex-wrap: wrap;
   gap: 8px;
   font-size: 11px;
+  color: var(--trace-muted);
 }
 
 .graph-node-card .fn-name {
@@ -522,19 +524,7 @@
   color: var(--trace-muted);
 }
 
-.graph-node-card .return {
-  color: var(--trace-muted-strong);
-}
-
-.graph-node-card .return.is-throw {
-  color: var(--trace-error);
-  font-weight: 600;
-}
-
-.graph-node-card .arrow {
-  opacity: 0.6;
-}
-
+.graph-node-card .call-tag,
 .graph-node-card .event-badge {
   font-size: 10px;
   text-transform: uppercase;
@@ -542,16 +532,15 @@
   align-self: flex-start;
   padding: 2px 6px;
   border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  background: rgba(148, 163, 184, 0.15);
 }
 
 .trace-graph-wrapper .react-flow__panel {
-  background: rgba(8, 12, 20, 0.86);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(248, 250, 252, 0.95);
+  border: 1px solid var(--trace-border);
   border-radius: 14px;
-  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.35);
-  backdrop-filter: blur(10px);
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.12);
   overflow: hidden;
 }
 
@@ -559,14 +548,14 @@
   width: 34px;
   height: 34px;
   border-radius: 50%;
-  background: rgba(18, 24, 34, 0.86);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: #ffffff;
+  border: 1px solid var(--trace-border);
   color: var(--trace-fg);
   transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 }
 
 .trace-graph-wrapper .react-flow__controls-button:hover:not(:disabled) {
-  background: rgba(36, 46, 64, 0.95);
+  background: var(--trace-card-hover);
   border-color: var(--trace-border-strong);
 }
 
@@ -579,30 +568,17 @@
 }
 
 .trace-graph-wrapper .react-flow__minimap {
-  background: rgba(7, 9, 12, 0.82);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(241, 245, 249, 0.9);
+  border: 1px solid var(--trace-border);
   border-radius: 12px;
 }
 
 .trace-graph-wrapper .react-flow__minimap-mask {
-  fill: rgba(7, 9, 12, 0.82);
+  fill: rgba(241, 245, 249, 0.95);
 }
 
 .trace-graph-wrapper .react-flow__background {
-  background: repeating-linear-gradient(
-      90deg,
-      rgba(90, 176, 255, 0.05) 0px,
-      rgba(90, 176, 255, 0.05) 1px,
-      transparent 1px,
-      transparent 40px
-    ),
-    repeating-linear-gradient(
-      0deg,
-      rgba(90, 176, 255, 0.05) 0px,
-      rgba(90, 176, 255, 0.05) 1px,
-      transparent 1px,
-      transparent 40px
-    );
+  background: #f1f5f9;
 }
 
 .trace-graph-empty {
@@ -614,7 +590,7 @@
   font-size: 15px;
   color: var(--trace-muted);
   pointer-events: none;
-  background: linear-gradient(180deg, rgba(8, 12, 20, 0.4), rgba(8, 12, 20, 0.6));
+  background: rgba(248, 250, 252, 0.92);
 }
 
 @media (max-width: 820px) {
@@ -633,24 +609,25 @@
   .trace-toolbar {
     flex-direction: column;
     align-items: flex-start;
+    gap: 12px;
   }
 }
+
 .trace-graph-wrapper { width: 100%; height: 100%; min-height: 420px; position: relative; }
 .trace-graph-flow { width: 100%; height: 100%; }
 
-/* Highlight the currently focused node */
 .react-flow__node.is-focused .graph-node-card,
 .graph-node-card.is-focused {
-  box-shadow: 0 0 0 3px rgba(250, 200, 50, 0.9);
+  box-shadow: 0 0 0 3px rgba(250, 204, 21, 0.6);
   outline: none;
 }
 
-/* FunctionTraceViewer.css – add somewhere near your node styles */
 .graph-node-card.is-ghost,
 .trace-card.is-ghost {
   opacity: 0.45;
-  filter: saturate(0.6);
+  filter: saturate(0.7);
 }
+
 .graph-node-card .ghost-pill {
   display: inline-block;
   padding: 2px 6px;

--- a/src/components/FunctionTracerViewer.jsx
+++ b/src/components/FunctionTracerViewer.jsx
@@ -585,7 +585,7 @@ function TraceGraphView({ graph }) {
 }
 
 /* ============================== Wrapper ================================ */
-export function FunctionTraceViewer({ trace = [], title = "Function trace" }) {
+export function FunctionTraceViewer({ trace = [], title = "Function trace", className = "" }) {
   const events = useMemo(() => normalizeTrace(trace), [trace]);
   const calls = useMemo(() => buildCallTree(events), [events]);
 
@@ -634,7 +634,7 @@ export function FunctionTraceViewer({ trace = [], title = "Function trace" }) {
   const graph = useMemo(() => buildGraphLayout(filtered, { pack: true }), [filtered]);
 
   return (
-      <div className="trace-viewer">
+      <div className={`trace-viewer${className ? ` ${className}` : ""}`}>
         <div className="trace-header">
           <div className="trace-heading">
             <h2>{title}</h2>

--- a/src/hooks/useSessionTraces.js
+++ b/src/hooks/useSessionTraces.js
@@ -1,0 +1,160 @@
+import { useEffect, useMemo, useState } from "react";
+
+const API_BASE = import.meta.env.VITE_API_BASE || "http://localhost:4000";
+
+function decodeBase64(text) {
+    if (!text) return null;
+    if (typeof atob === "function") {
+        try { return atob(text); } catch { /* ignore */ }
+    }
+    if (typeof Buffer !== "undefined") {
+        try { return Buffer.from(text, "base64").toString("utf-8"); } catch { /* ignore */ }
+    }
+    return null;
+}
+
+function parseNdjson(text) {
+    const lines = String(text)
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean);
+    if (!lines.length) return null;
+    const out = [];
+    for (const line of lines) {
+        try {
+            const parsed = JSON.parse(line);
+            out.push(parsed);
+        } catch {
+            return null;
+        }
+    }
+    return out;
+}
+
+function parseTraceEvents(payload) {
+    if (!payload) return [];
+    if (Array.isArray(payload)) return payload.filter(Boolean);
+    if (typeof payload === "object") {
+        if (Array.isArray(payload.events)) return payload.events.filter(Boolean);
+        if (payload.events) return parseTraceEvents(payload.events);
+        if (Array.isArray(payload.data)) return payload.data.filter(Boolean);
+        if (payload.data) return parseTraceEvents(payload.data);
+        return [];
+    }
+    if (typeof payload !== "string") return [];
+
+    const trimmed = payload.trim();
+    if (!trimmed) return [];
+
+    const tryParseJson = (text) => {
+        try {
+            const parsed = JSON.parse(text);
+            if (Array.isArray(parsed)) return parsed.filter(Boolean);
+            if (parsed && Array.isArray(parsed.events)) return parsed.events.filter(Boolean);
+            return null;
+        } catch {
+            return null;
+        }
+    };
+
+    const fromJson = tryParseJson(trimmed);
+    if (fromJson) return fromJson;
+
+    const fromNdjson = parseNdjson(trimmed);
+    if (fromNdjson) return fromNdjson;
+
+    const decoded = decodeBase64(trimmed);
+    if (decoded) {
+        const decodedJson = tryParseJson(decoded);
+        if (decodedJson) return decodedJson;
+        const decodedNdjson = parseNdjson(decoded);
+        if (decodedNdjson) return decodedNdjson;
+    }
+
+    return [];
+}
+
+function normalizeTraceItems(rawItems = []) {
+    const entries = [];
+
+    rawItems.forEach((group, groupIndex) => {
+        (group.traces || []).forEach((trace, traceIndex) => {
+            const batches = trace?.batches || [];
+            const events = [];
+            let declaredTotal = 0;
+
+            batches.forEach((batch) => {
+                const batchTrace = batch?.trace ?? {};
+                const payload = batchTrace.events ?? batchTrace.data ?? batchTrace;
+                const parsed = parseTraceEvents(payload);
+                if (parsed.length) events.push(...parsed);
+                if (Number.isFinite(batchTrace.total)) declaredTotal += Number(batchTrace.total);
+                else if (Array.isArray(batchTrace.events)) declaredTotal += batchTrace.events.length;
+                else if (parsed.length) declaredTotal += parsed.length;
+            });
+
+            const idParts = [group.key || `group-${groupIndex}`, trace.requestRid || `trace-${traceIndex}`];
+            const id = idParts.join("::");
+            const requestMeta = trace?.request || {};
+            const label = requestMeta.key || group.key || `Trace ${entries.length + 1}`;
+            const total = declaredTotal || events.length;
+
+            entries.push({
+                id,
+                groupKey: group.key,
+                requestRid: trace.requestRid,
+                request: requestMeta,
+                batches,
+                events,
+                total,
+                label,
+            });
+        });
+    });
+
+    return entries;
+}
+
+export default function useSessionTraces(sessionId) {
+    const [status, setStatus] = useState("idle");
+    const [error, setError] = useState(null);
+    const [rawItems, setRawItems] = useState([]);
+
+    useEffect(() => {
+        if (!sessionId) {
+            setRawItems([]);
+            setStatus("idle");
+            setError(null);
+            return undefined;
+        }
+
+        let aborted = false;
+        setStatus("loading");
+        setError(null);
+        setRawItems([]);
+
+        (async () => {
+            try {
+                const response = await fetch(`${API_BASE}/v1/sessions/${sessionId}/traces`);
+                if (!response.ok) throw new Error(`Trace request failed with status ${response.status}`);
+                const json = await response.json();
+                if (aborted) return;
+                setRawItems(json?.items || []);
+                setStatus("ready");
+            } catch (err) {
+                if (aborted) return;
+                console.error("[repro:trace] failed to load traces", err);
+                setError(err);
+                setStatus("error");
+            }
+        })();
+
+        return () => {
+            aborted = true;
+        };
+    }, [sessionId]);
+
+    const entries = useMemo(() => normalizeTraceItems(rawItems), [rawItems]);
+
+    return { status, error, items: rawItems, entries };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -26,6 +26,7 @@ body {
 * {
   scrollbar-width: thin;
   scrollbar-color: rgba(148, 163, 184, 0.6) rgba(226, 232, 240, 0.6);
+  border-radius: 0 !important;
 }
 
 *::-webkit-scrollbar {
@@ -35,12 +36,10 @@ body {
 
 *::-webkit-scrollbar-track {
   background: rgba(226, 232, 240, 0.6);
-  border-radius: 999px;
 }
 
 *::-webkit-scrollbar-thumb {
   background: rgba(148, 163, 184, 0.7);
-  border-radius: 999px;
 }
 
 *::-webkit-scrollbar-thumb:hover {

--- a/src/index.css
+++ b/src/index.css
@@ -9,7 +9,7 @@
 
   color-scheme: dark;
   color: rgb(226, 232, 240);
-  background-color: #020617;
+  background-color: #0f1b2f;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -19,6 +19,30 @@
 
 body {
   margin: 0;
-  background-color: #020617;
+  background-color: #0f1b2f;
+}
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(148, 163, 184, 0.6) rgba(15, 23, 42, 0.55);
+}
+
+*::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+*::-webkit-scrollbar-track {
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 999px;
+}
+
+*::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.7);
+  border-radius: 999px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background: rgba(148, 163, 184, 0.9);
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -7,9 +7,9 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: dark;
-  color: rgb(226, 232, 240);
-  background-color: #0f1b2f;
+  color-scheme: light;
+  color: #0f172a;
+  background-color: #f8fafc;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -19,12 +19,13 @@
 
 body {
   margin: 0;
-  background-color: #0f1b2f;
+  background-color: #f8fafc;
+  color: #0f172a;
 }
 
 * {
   scrollbar-width: thin;
-  scrollbar-color: rgba(148, 163, 184, 0.6) rgba(15, 23, 42, 0.55);
+  scrollbar-color: rgba(148, 163, 184, 0.6) rgba(226, 232, 240, 0.6);
 }
 
 *::-webkit-scrollbar {
@@ -33,7 +34,7 @@ body {
 }
 
 *::-webkit-scrollbar-track {
-  background: rgba(15, 23, 42, 0.45);
+  background: rgba(226, 232, 240, 0.6);
   border-radius: 999px;
 }
 

--- a/src/pages/FunctionTracePage.jsx
+++ b/src/pages/FunctionTracePage.jsx
@@ -15,13 +15,13 @@ export default function FunctionTracePage() {
 
     const traces = useMemo(() => entries, [entries]);
     const selected = useMemo(() => {
-        if (!selectedId && traces.length) return traces[0];
+        if (!selectedId) return null;
         return traces.find((entry) => entry.id === selectedId) || null;
     }, [selectedId, traces]);
 
     useEffect(() => {
-        if (!selectedId && traces.length) {
-            setSelectedId(traces[0].id);
+        if (selectedId && !traces.find((entry) => entry.id === selectedId)) {
+            setSelectedId(null);
         }
     }, [selectedId, traces]);
 
@@ -30,82 +30,72 @@ export default function FunctionTracePage() {
         : "Function trace";
 
     return (
-        <div className="min-h-screen bg-slate-900 text-slate-100">
-            <div className="relative min-h-screen overflow-hidden">
-                <div className="pointer-events-none absolute inset-0">
-                    <div className="absolute -left-28 top-[-6%] h-80 w-80 rounded-full bg-sky-400/30 blur-3xl" />
-                    <div className="absolute bottom-0 right-0 h-96 w-96 rounded-full bg-fuchsia-400/20 blur-[140px]" />
-                </div>
-                <div className="relative mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-6 pb-16 pt-12 sm:px-10">
-                    <header className="flex flex-col gap-2">
-                        <p className="text-xs uppercase tracking-[0.4em] text-slate-300">Session traces</p>
-                        <h1 className="text-3xl font-semibold tracking-tight text-slate-50 sm:text-4xl">Function trace explorer</h1>
-                        <p className="text-sm text-slate-300">Session ID: {sessionId || "—"}</p>
-                    </header>
+        <div className="min-h-screen bg-slate-50 text-slate-900">
+            <div className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-6 pb-16 pt-12 sm:px-10">
+                <header className="flex flex-col gap-2">
+                    <p className="text-xs font-semibold uppercase tracking-[0.32em] text-slate-500">Session traces</p>
+                    <h1 className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">Function trace explorer</h1>
+                    <p className="text-sm text-slate-600">Session ID: {sessionId || "—"}</p>
+                </header>
 
-                    {!sessionId && (
-                        <div className="rounded-2xl border border-slate-700/60 bg-slate-900/60 px-6 py-5 text-sm text-slate-200 shadow-xl backdrop-blur">
-                            Provide a session id in the query string, e.g. <code className="rounded bg-slate-800 px-1 py-0.5">?sessionId=YOUR_SESSION_ID</code>, to load trace data.
-                        </div>
-                    )}
+                {!sessionId && (
+                    <div className="rounded-2xl border border-slate-200 bg-white px-6 py-5 text-sm text-slate-600 shadow-sm">
+                        Provide a session id in the query string, e.g. <code className="rounded bg-slate-100 px-1 py-0.5 text-slate-900">?sessionId=YOUR_SESSION_ID</code>, to load trace data.
+                    </div>
+                )}
 
-                    {sessionId && status === "loading" && (
-                        <div className="flex flex-1 items-center justify-center rounded-2xl border border-slate-700/60 bg-slate-900/55">
-                            <div className="animate-pulse text-sm text-slate-300">Fetching trace data…</div>
-                        </div>
-                    )}
+                {sessionId && status === "loading" && (
+                    <div className="flex flex-1 items-center justify-center rounded-2xl border border-slate-200 bg-slate-50">
+                        <div className="animate-pulse text-sm text-slate-500">Fetching trace data…</div>
+                    </div>
+                )}
 
-                    {sessionId && status === "error" && (
-                        <div className="rounded-2xl border border-rose-500/40 bg-rose-500/15 px-6 py-5 text-sm text-rose-100">
-                            Unable to load traces for this session. Please try again later.
-                        </div>
-                    )}
+                {sessionId && status === "error" && (
+                    <div className="rounded-2xl border border-rose-200 bg-rose-50 px-6 py-5 text-sm text-rose-600">
+                        Unable to load traces for this session. Please try again later.
+                    </div>
+                )}
 
-                    {sessionId && status === "ready" && traces.length === 0 && (
-                        <div className="rounded-2xl border border-slate-700/60 bg-slate-900/60 px-6 py-5 text-sm text-slate-200">
-                            No function traces were captured for this session.
-                        </div>
-                    )}
+                {sessionId && status === "ready" && traces.length === 0 && (
+                    <div className="rounded-2xl border border-slate-200 bg-slate-50 px-6 py-5 text-sm text-slate-600">
+                        No function traces were captured for this session.
+                    </div>
+                )}
 
-                    {sessionId && status === "ready" && traces.length > 0 && (
-                        <div className="grid flex-1 gap-6 lg:grid-cols-[320px_minmax(0,1fr)]">
-                            <aside className="flex flex-col gap-3 rounded-2xl border border-slate-800/60 bg-slate-900/70 p-5 backdrop-blur">
-                                <p className="text-xs uppercase tracking-[0.3em] text-slate-300">Requests</p>
-                                <div className="space-y-3 overflow-y-auto pr-1">
-                                    {traces.map((entry) => {
-                                        const isActive = entry.id === (selected?.id || selectedId);
-                                        const meta = entry.request || {};
-                                        return (
-                                            <button
-                                                key={entry.id}
-                                                type="button"
-                                                onClick={() => setSelectedId(entry.id)}
-                                                className={`w-full rounded-xl border px-4 py-3 text-left text-sm transition focus:outline-none focus:ring-2 focus:ring-sky-500 ${
-                                                    isActive
-                                                        ? "border-sky-500/60 bg-sky-500/10 text-slate-100"
-                                                        : "border-slate-700/60 bg-slate-900/45 text-slate-200 hover:border-slate-600 hover:bg-slate-900/65"
-                                                }`}
-                                            >
-                                                <div className="font-mono text-xs text-slate-300">{entry.label}</div>
-                                                <div className="mt-2 flex items-center justify-between text-xs text-slate-300">
-                                                    <span>Status {meta.status ?? "—"}</span>
-                                                    <span>{meta.durMs != null ? `${meta.durMs}ms` : "—"}</span>
-                                                </div>
-                                                <div className="mt-1 text-[11px] uppercase tracking-[0.25em] text-slate-300">
-                                                    {entry.total} events
-                                                </div>
-                                            </button>
-                                        );
-                                    })}
+                {sessionId && status === "ready" && traces.length > 0 && (
+                    <div className="flex flex-1 flex-col gap-4 pb-8">
+                        <p className="text-xs text-slate-500">Select a trace below to expand its captured events.</p>
+                        {traces.map((entry) => {
+                            const isActive = entry.id === selected?.id;
+                            const meta = entry.request || {};
+                            const label = entry.label || meta.method || entry.id;
+                            return (
+                                <div key={entry.id} className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+                                    <button
+                                        type="button"
+                                        onClick={() => setSelectedId(entry.id)}
+                                        className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white"
+                                    >
+                                        <div>
+                                            <div className="text-sm font-semibold text-slate-900">{label}</div>
+                                            <div className="mt-1 flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.25em] text-slate-500">
+                                                <span>Status {meta.status ?? "—"}</span>
+                                                <span>{meta.durMs != null ? `${meta.durMs}ms` : "—"}</span>
+                                                <span>{entry.total} events</span>
+                                            </div>
+                                        </div>
+                                        <span className="text-slate-400">{isActive ? "▾" : "▸"}</span>
+                                    </button>
+                                    {isActive && (
+                                        <div className="border-t border-slate-200 bg-slate-50 px-2 py-4 sm:px-4">
+                                            <FunctionTraceViewer trace={selected?.events || []} title={title} className="is-embedded" />
+                                        </div>
+                                    )}
                                 </div>
-                            </aside>
-
-                            <div className="flex min-h-0 flex-col rounded-2xl border border-slate-800/60 bg-slate-900/75 p-5 backdrop-blur">
-                                <FunctionTraceViewer trace={selected?.events || []} title={title} className="is-embedded" />
-                            </div>
-                        </div>
-                    )}
-                </div>
+                            );
+                        })}
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/src/pages/FunctionTracePage.jsx
+++ b/src/pages/FunctionTracePage.jsx
@@ -30,73 +30,82 @@ export default function FunctionTracePage() {
         : "Function trace";
 
     return (
-        <div className="min-h-screen bg-slate-50 text-slate-900">
-            <div className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-6 pb-16 pt-12 sm:px-10">
-                <header className="flex flex-col gap-2">
-                    <p className="text-xs font-semibold uppercase tracking-[0.32em] text-slate-500">Session traces</p>
-                    <h1 className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">Function trace explorer</h1>
-                    <p className="text-sm text-slate-600">Session ID: {sessionId || "—"}</p>
-                </header>
-
+        <div className="flex min-h-screen flex-col bg-slate-100 text-slate-900">
+            <header className="border-b border-slate-200 bg-white px-8 py-5">
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                    <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.4em] text-slate-500">Session traces</p>
+                        <h1 className="text-2xl font-semibold tracking-tight text-slate-900">Function trace explorer</h1>
+                    </div>
+                    <div className="text-xs text-slate-600">Session {sessionId || "—"}</div>
+                </div>
+            </header>
+            <main className="flex flex-1 min-h-0 flex-col gap-6 px-8 py-6">
                 {!sessionId && (
-                    <div className="rounded-2xl border border-slate-200 bg-white px-6 py-5 text-sm text-slate-600 shadow-sm">
-                        Provide a session id in the query string, e.g. <code className="rounded bg-slate-100 px-1 py-0.5 text-slate-900">?sessionId=YOUR_SESSION_ID</code>, to load trace data.
+                    <div className="border border-slate-200 bg-white px-4 py-4 text-sm text-slate-600">
+                        Provide a session id in the query string, e.g.
+                        <code className="ml-2 bg-slate-200 px-2 py-1 text-xs text-slate-900">?sessionId=YOUR_SESSION_ID</code>
+                        , to load trace data.
                     </div>
                 )}
 
                 {sessionId && status === "loading" && (
-                    <div className="flex flex-1 items-center justify-center rounded-2xl border border-slate-200 bg-slate-50">
-                        <div className="animate-pulse text-sm text-slate-500">Fetching trace data…</div>
+                    <div className="flex flex-1 items-center justify-center border border-slate-200 bg-white text-sm text-slate-600">
+                        Fetching trace data…
                     </div>
                 )}
 
                 {sessionId && status === "error" && (
-                    <div className="rounded-2xl border border-rose-200 bg-rose-50 px-6 py-5 text-sm text-rose-600">
+                    <div className="border border-rose-400 bg-rose-50 px-4 py-4 text-sm text-rose-700">
                         Unable to load traces for this session. Please try again later.
                     </div>
                 )}
 
                 {sessionId && status === "ready" && traces.length === 0 && (
-                    <div className="rounded-2xl border border-slate-200 bg-slate-50 px-6 py-5 text-sm text-slate-600">
+                    <div className="border border-slate-200 bg-slate-100 px-4 py-4 text-sm text-slate-600">
                         No function traces were captured for this session.
                     </div>
                 )}
 
                 {sessionId && status === "ready" && traces.length > 0 && (
-                    <div className="flex flex-1 flex-col gap-4 pb-8">
+                    <div className="flex min-h-0 flex-1 flex-col gap-4">
                         <p className="text-xs text-slate-500">Select a trace below to expand its captured events.</p>
-                        {traces.map((entry) => {
-                            const isActive = entry.id === selected?.id;
-                            const meta = entry.request || {};
-                            const label = entry.label || meta.method || entry.id;
-                            return (
-                                <div key={entry.id} className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
-                                    <button
-                                        type="button"
-                                        onClick={() => setSelectedId(entry.id)}
-                                        className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white"
-                                    >
-                                        <div>
-                                            <div className="text-sm font-semibold text-slate-900">{label}</div>
-                                            <div className="mt-1 flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.25em] text-slate-500">
-                                                <span>Status {meta.status ?? "—"}</span>
-                                                <span>{meta.durMs != null ? `${meta.durMs}ms` : "—"}</span>
-                                                <span>{entry.total} events</span>
+                        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
+                            {traces.map((entry) => {
+                                const isActive = entry.id === selected?.id;
+                                const meta = entry.request || {};
+                                const label = entry.label || meta.method || entry.id;
+                                return (
+                                    <div key={entry.id} className="border border-slate-200 bg-white">
+                                        <button
+                                            type="button"
+                                            onClick={() => setSelectedId(entry.id)}
+                                            className={`flex w-full items-center justify-between gap-4 px-4 py-3 text-left transition ${
+                                                isActive ? "bg-slate-100" : "bg-white hover:bg-slate-50"
+                                            }`}
+                                        >
+                                            <div>
+                                                <div className="text-sm font-semibold text-slate-900">{label}</div>
+                                                <div className="mt-1 flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.25em] text-slate-500">
+                                                    <span>Status {meta.status ?? "—"}</span>
+                                                    <span>{meta.durMs != null ? `${meta.durMs}ms` : "—"}</span>
+                                                    <span>{entry.total} events</span>
+                                                </div>
                                             </div>
-                                        </div>
-                                        <span className="text-slate-400">{isActive ? "▾" : "▸"}</span>
-                                    </button>
-                                    {isActive && (
-                                        <div className="border-t border-slate-200 bg-slate-50 px-2 py-4 sm:px-4">
-                                            <FunctionTraceViewer trace={selected?.events || []} title={title} className="is-embedded" />
-                                        </div>
-                                    )}
-                                </div>
-                            );
-                        })}
+                                            <span className="text-slate-400">{isActive ? "▾" : "▸"}</span>
+                                        </button>
+                                        {isActive && (
+                                            <div className="border-t border-slate-200 bg-slate-50 px-4 py-4">
+                                                <FunctionTraceViewer trace={selected?.events || []} title={title} className="is-embedded" />
+                                            </div>
+                                        )}
+                                    </div>
+                                );
+                            })}
+                        </div>
                     </div>
                 )}
-            </div>
+            </main>
         </div>
     );
 }

--- a/src/pages/FunctionTracePage.jsx
+++ b/src/pages/FunctionTracePage.jsx
@@ -30,47 +30,47 @@ export default function FunctionTracePage() {
         : "Function trace";
 
     return (
-        <div className="min-h-screen bg-slate-950 text-slate-100">
+        <div className="min-h-screen bg-slate-900 text-slate-100">
             <div className="relative min-h-screen overflow-hidden">
                 <div className="pointer-events-none absolute inset-0">
-                    <div className="absolute -left-32 top-0 h-80 w-80 rounded-full bg-sky-500/20 blur-3xl" />
-                    <div className="absolute bottom-0 right-0 h-96 w-96 rounded-full bg-fuchsia-500/10 blur-[140px]" />
+                    <div className="absolute -left-28 top-[-6%] h-80 w-80 rounded-full bg-sky-400/30 blur-3xl" />
+                    <div className="absolute bottom-0 right-0 h-96 w-96 rounded-full bg-fuchsia-400/20 blur-[140px]" />
                 </div>
                 <div className="relative mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-6 pb-16 pt-12 sm:px-10">
                     <header className="flex flex-col gap-2">
-                        <p className="text-xs uppercase tracking-[0.4em] text-slate-500">Session traces</p>
-                        <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Function trace explorer</h1>
-                        <p className="text-sm text-slate-400">Session ID: {sessionId || "—"}</p>
+                        <p className="text-xs uppercase tracking-[0.4em] text-slate-300">Session traces</p>
+                        <h1 className="text-3xl font-semibold tracking-tight text-slate-50 sm:text-4xl">Function trace explorer</h1>
+                        <p className="text-sm text-slate-300">Session ID: {sessionId || "—"}</p>
                     </header>
 
                     {!sessionId && (
-                        <div className="rounded-2xl border border-slate-800/60 bg-slate-900/70 px-6 py-5 text-sm text-slate-300 shadow-xl backdrop-blur">
+                        <div className="rounded-2xl border border-slate-700/60 bg-slate-900/60 px-6 py-5 text-sm text-slate-200 shadow-xl backdrop-blur">
                             Provide a session id in the query string, e.g. <code className="rounded bg-slate-800 px-1 py-0.5">?sessionId=YOUR_SESSION_ID</code>, to load trace data.
                         </div>
                     )}
 
                     {sessionId && status === "loading" && (
-                        <div className="flex flex-1 items-center justify-center rounded-2xl border border-slate-800/60 bg-slate-900/50">
-                            <div className="animate-pulse text-sm text-slate-400">Fetching trace data…</div>
+                        <div className="flex flex-1 items-center justify-center rounded-2xl border border-slate-700/60 bg-slate-900/55">
+                            <div className="animate-pulse text-sm text-slate-300">Fetching trace data…</div>
                         </div>
                     )}
 
                     {sessionId && status === "error" && (
-                        <div className="rounded-2xl border border-rose-500/40 bg-rose-500/10 px-6 py-5 text-sm text-rose-200">
+                        <div className="rounded-2xl border border-rose-500/40 bg-rose-500/15 px-6 py-5 text-sm text-rose-100">
                             Unable to load traces for this session. Please try again later.
                         </div>
                     )}
 
                     {sessionId && status === "ready" && traces.length === 0 && (
-                        <div className="rounded-2xl border border-slate-800/60 bg-slate-900/70 px-6 py-5 text-sm text-slate-300">
+                        <div className="rounded-2xl border border-slate-700/60 bg-slate-900/60 px-6 py-5 text-sm text-slate-200">
                             No function traces were captured for this session.
                         </div>
                     )}
 
                     {sessionId && status === "ready" && traces.length > 0 && (
                         <div className="grid flex-1 gap-6 lg:grid-cols-[320px_minmax(0,1fr)]">
-                            <aside className="flex flex-col gap-3 rounded-2xl border border-slate-900/70 bg-slate-950/70 p-5 backdrop-blur">
-                                <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Requests</p>
+                            <aside className="flex flex-col gap-3 rounded-2xl border border-slate-800/60 bg-slate-900/70 p-5 backdrop-blur">
+                                <p className="text-xs uppercase tracking-[0.3em] text-slate-300">Requests</p>
                                 <div className="space-y-3 overflow-y-auto pr-1">
                                     {traces.map((entry) => {
                                         const isActive = entry.id === (selected?.id || selectedId);
@@ -83,15 +83,15 @@ export default function FunctionTracePage() {
                                                 className={`w-full rounded-xl border px-4 py-3 text-left text-sm transition focus:outline-none focus:ring-2 focus:ring-sky-500 ${
                                                     isActive
                                                         ? "border-sky-500/60 bg-sky-500/10 text-slate-100"
-                                                        : "border-slate-800/60 bg-slate-950/40 text-slate-300 hover:border-slate-700 hover:bg-slate-900/60"
+                                                        : "border-slate-700/60 bg-slate-900/45 text-slate-200 hover:border-slate-600 hover:bg-slate-900/65"
                                                 }`}
                                             >
-                                                <div className="font-mono text-xs text-slate-400">{entry.label}</div>
-                                                <div className="mt-2 flex items-center justify-between text-xs text-slate-500">
+                                                <div className="font-mono text-xs text-slate-300">{entry.label}</div>
+                                                <div className="mt-2 flex items-center justify-between text-xs text-slate-300">
                                                     <span>Status {meta.status ?? "—"}</span>
                                                     <span>{meta.durMs != null ? `${meta.durMs}ms` : "—"}</span>
                                                 </div>
-                                                <div className="mt-1 text-[11px] uppercase tracking-[0.25em] text-slate-500">
+                                                <div className="mt-1 text-[11px] uppercase tracking-[0.25em] text-slate-300">
                                                     {entry.total} events
                                                 </div>
                                             </button>
@@ -100,7 +100,7 @@ export default function FunctionTracePage() {
                                 </div>
                             </aside>
 
-                            <div className="flex min-h-0 flex-col rounded-2xl border border-slate-900/70 bg-slate-950/80 p-5 backdrop-blur">
+                            <div className="flex min-h-0 flex-col rounded-2xl border border-slate-800/60 bg-slate-900/75 p-5 backdrop-blur">
                                 <FunctionTraceViewer trace={selected?.events || []} title={title} className="is-embedded" />
                             </div>
                         </div>

--- a/src/pages/FunctionTracePage.jsx
+++ b/src/pages/FunctionTracePage.jsx
@@ -1,22 +1,112 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { FunctionTraceViewer } from "../components/FunctionTracerViewer.jsx";
-
-const traceData = [];
+import useSessionTraces from "../hooks/useSessionTraces.js";
 
 export default function FunctionTracePage() {
-  const trace = useMemo(() => traceData, []);
+    const [search] = useSearchParams();
+    const sessionId = search.get("sessionId") || "";
+    const { status, entries } = useSessionTraces(sessionId);
+    const [selectedId, setSelectedId] = useState(null);
 
-  return (
-    <div
-      style={{
-        minHeight: "100vh",
-        padding: "48px clamp(32px, 6vw, 72px)",
-        background: "radial-gradient(circle at top, rgba(42,78,170,0.4), transparent 55%), #02040a",
-        display: "flex",
-        flexDirection: "column"
-      }}
-    >
-      <FunctionTraceViewer trace={trace} title="Function Call Trace" />
-    </div>
-  );
+    useEffect(() => {
+        setSelectedId(null);
+    }, [sessionId]);
+
+    const traces = useMemo(() => entries, [entries]);
+    const selected = useMemo(() => {
+        if (!selectedId && traces.length) return traces[0];
+        return traces.find((entry) => entry.id === selectedId) || null;
+    }, [selectedId, traces]);
+
+    useEffect(() => {
+        if (!selectedId && traces.length) {
+            setSelectedId(traces[0].id);
+        }
+    }, [selectedId, traces]);
+
+    const title = selected
+        ? `${selected.label || "Function trace"} (${selected.total || selected.events.length || 0} events)`
+        : "Function trace";
+
+    return (
+        <div className="min-h-screen bg-slate-950 text-slate-100">
+            <div className="relative min-h-screen overflow-hidden">
+                <div className="pointer-events-none absolute inset-0">
+                    <div className="absolute -left-32 top-0 h-80 w-80 rounded-full bg-sky-500/20 blur-3xl" />
+                    <div className="absolute bottom-0 right-0 h-96 w-96 rounded-full bg-fuchsia-500/10 blur-[140px]" />
+                </div>
+                <div className="relative mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-6 pb-16 pt-12 sm:px-10">
+                    <header className="flex flex-col gap-2">
+                        <p className="text-xs uppercase tracking-[0.4em] text-slate-500">Session traces</p>
+                        <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Function trace explorer</h1>
+                        <p className="text-sm text-slate-400">Session ID: {sessionId || "—"}</p>
+                    </header>
+
+                    {!sessionId && (
+                        <div className="rounded-2xl border border-slate-800/60 bg-slate-900/70 px-6 py-5 text-sm text-slate-300 shadow-xl backdrop-blur">
+                            Provide a session id in the query string, e.g. <code className="rounded bg-slate-800 px-1 py-0.5">?sessionId=YOUR_SESSION_ID</code>, to load trace data.
+                        </div>
+                    )}
+
+                    {sessionId && status === "loading" && (
+                        <div className="flex flex-1 items-center justify-center rounded-2xl border border-slate-800/60 bg-slate-900/50">
+                            <div className="animate-pulse text-sm text-slate-400">Fetching trace data…</div>
+                        </div>
+                    )}
+
+                    {sessionId && status === "error" && (
+                        <div className="rounded-2xl border border-rose-500/40 bg-rose-500/10 px-6 py-5 text-sm text-rose-200">
+                            Unable to load traces for this session. Please try again later.
+                        </div>
+                    )}
+
+                    {sessionId && status === "ready" && traces.length === 0 && (
+                        <div className="rounded-2xl border border-slate-800/60 bg-slate-900/70 px-6 py-5 text-sm text-slate-300">
+                            No function traces were captured for this session.
+                        </div>
+                    )}
+
+                    {sessionId && status === "ready" && traces.length > 0 && (
+                        <div className="grid flex-1 gap-6 lg:grid-cols-[320px_minmax(0,1fr)]">
+                            <aside className="flex flex-col gap-3 rounded-2xl border border-slate-900/70 bg-slate-950/70 p-5 backdrop-blur">
+                                <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Requests</p>
+                                <div className="space-y-3 overflow-y-auto pr-1">
+                                    {traces.map((entry) => {
+                                        const isActive = entry.id === (selected?.id || selectedId);
+                                        const meta = entry.request || {};
+                                        return (
+                                            <button
+                                                key={entry.id}
+                                                type="button"
+                                                onClick={() => setSelectedId(entry.id)}
+                                                className={`w-full rounded-xl border px-4 py-3 text-left text-sm transition focus:outline-none focus:ring-2 focus:ring-sky-500 ${
+                                                    isActive
+                                                        ? "border-sky-500/60 bg-sky-500/10 text-slate-100"
+                                                        : "border-slate-800/60 bg-slate-950/40 text-slate-300 hover:border-slate-700 hover:bg-slate-900/60"
+                                                }`}
+                                            >
+                                                <div className="font-mono text-xs text-slate-400">{entry.label}</div>
+                                                <div className="mt-2 flex items-center justify-between text-xs text-slate-500">
+                                                    <span>Status {meta.status ?? "—"}</span>
+                                                    <span>{meta.durMs != null ? `${meta.durMs}ms` : "—"}</span>
+                                                </div>
+                                                <div className="mt-1 text-[11px] uppercase tracking-[0.25em] text-slate-500">
+                                                    {entry.total} events
+                                                </div>
+                                            </button>
+                                        );
+                                    })}
+                                </div>
+                            </aside>
+
+                            <div className="flex min-h-0 flex-col rounded-2xl border border-slate-900/70 bg-slate-950/80 p-5 backdrop-blur">
+                                <FunctionTraceViewer trace={selected?.events || []} title={title} className="is-embedded" />
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
 }

--- a/src/pages/SessionReplay.jsx
+++ b/src/pages/SessionReplay.jsx
@@ -1007,7 +1007,7 @@ export default function SessionReplay({ sessionId }) {
     );
 
     const timelinePanel = (
-        <aside className="flex min-h-0 min-w-0 max-w-full flex-1 flex-col overflow-hidden border-t border-slate-200 bg-white lg:border-l lg:border-t-0">
+        <aside className="flex h-full min-h-0 min-w-0 max-w-full flex-1 flex-col overflow-hidden border-t border-slate-200 bg-white lg:border-l lg:border-t-0">
             <div className="border-b border-slate-200 px-6 py-4">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                     <div>
@@ -1284,11 +1284,11 @@ export default function SessionReplay({ sessionId }) {
             </header>
             <main className="flex flex-1 min-h-0 min-w-0 flex-col overflow-x-hidden">
                 {viewMode === "replay" ? (
-                    <div className="flex flex-1 min-h-0 flex-col lg:grid lg:grid-cols-[minmax(0,1fr)_26rem] xl:grid-cols-[minmax(0,1fr)_30rem]">
+                    <div className="flex flex-1 min-h-0 flex-col lg:flex-row">
                         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
                             {playbackSection}
                         </div>
-                        <div className="flex min-h-0 min-w-0 flex-1 flex-col lg:flex-none">
+                        <div className="flex min-h-0 min-w-0 flex-1 flex-col lg:w-[26rem] lg:flex-none lg:shrink-0 xl:w-[30rem]">
                             {timelinePanel}
                         </div>
                     </div>

--- a/src/pages/SessionReplay.jsx
+++ b/src/pages/SessionReplay.jsx
@@ -402,6 +402,10 @@ export default function SessionReplay({ sessionId }) {
 
     // ---- bootstrap rrweb ----
     useEffect(() => {
+        if (viewMode !== "replay") {
+            return;
+        }
+
         if (status !== "ready" || !containerRef.current || replayerRef.current) return;
 
         let cancelled = false;
@@ -530,7 +534,18 @@ export default function SessionReplay({ sessionId }) {
             if (mismatchSentinel) clearInterval(mismatchSentinel);
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [status]);
+    }, [status, viewMode]);
+
+    useEffect(() => {
+        if (viewMode === "replay") return;
+        try {
+            replayerRef.current?.pause();
+        } catch (err) {
+            warn("pause on view switch failed", err);
+        }
+        replayerRef.current = null;
+        setPlayerStatus((prev) => (prev === "playing" ? "paused" : prev));
+    }, [viewMode]);
 
     // recompute offset if ticks later
     useEffect(() => {
@@ -787,7 +802,7 @@ export default function SessionReplay({ sessionId }) {
 
 
     const playbackSection = (
-        <section className="flex min-h-0 flex-1 flex-col bg-white">
+        <section className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-white">
             <div className="flex items-center justify-between border-b border-slate-200 px-8 py-5">
                 <div>
                     <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Playback</p>
@@ -815,7 +830,7 @@ export default function SessionReplay({ sessionId }) {
                 </div>
             </div>
 
-            <div className="relative flex-1 min-h-0 bg-slate-100 px-8 py-6">
+            <div className="relative flex-1 min-h-0 min-w-0 overflow-hidden bg-slate-100 px-8 py-6">
                 <div ref={containerRef} className="h-full w-full border border-slate-300 bg-white" />
                 {playerStatus === "loading" && (
                     <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
@@ -978,7 +993,7 @@ export default function SessionReplay({ sessionId }) {
     );
 
     const timelinePanel = (
-        <aside className="flex min-h-0 flex-1 flex-col border-t border-slate-200 bg-white lg:border-l lg:border-t-0">
+        <aside className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden border-t border-slate-200 bg-white lg:border-l lg:border-t-0">
             <div className="border-b border-slate-200 px-8 py-4">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                     <div>
@@ -1213,7 +1228,7 @@ export default function SessionReplay({ sessionId }) {
     );
 
     return (
-        <div className="flex min-h-screen flex-col bg-slate-100 text-slate-900">
+        <div className="flex min-h-screen min-w-0 flex-col overflow-x-hidden bg-slate-100 text-slate-900">
             <header className="border-b border-slate-200 bg-white px-8 py-5">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                     <div className="flex items-center gap-4">
@@ -1253,13 +1268,13 @@ export default function SessionReplay({ sessionId }) {
                     <span>{viewMode === "replay" ? timelineSummaryText : traceSummaryText}</span>
                 </div>
             </header>
-            <main className="flex flex-1 min-h-0 flex-col">
+            <main className="flex flex-1 min-h-0 min-w-0 flex-col">
                 {viewMode === "replay" ? (
                     <div className="flex flex-1 min-h-0 flex-col lg:flex-row">
-                        <div className="flex min-h-0 flex-1 flex-col">
+                        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
                             {playbackSection}
                         </div>
-                        <div className="flex min-h-0 flex-col lg:w-[28rem] lg:flex-none">
+                        <div className="flex min-h-0 w-full min-w-0 flex-col lg:w-[24rem] lg:flex-none">
                             {timelinePanel}
                         </div>
                     </div>

--- a/src/pages/SessionReplay.jsx
+++ b/src/pages/SessionReplay.jsx
@@ -29,16 +29,12 @@ function LogoMark({ className = "", ...props }) {
             className={className}
             {...props}
         >
-            <rect x="3" y="3" width="42" height="42" rx="12" fill="#1f2937" />
+            <rect width="48" height="48" fill="#0f172a" />
+            <path d="M10 8h8v32h-8z" fill="#1d4ed8" />
             <path
-                d="M18 14.5c0-1.38 1.12-2.5 2.5-2.5h9.5c5.02 0 8.5 2.85 8.5 7.32 0 3.43-1.84 5.68-4.93 6.53l4.84 6.86c.52.74-.02 1.79-.93 1.79h-3.48a1.6 1.6 0 0 1-1.29-.65l-5.2-7.14h-2.68v6.29c0 .88-.72 1.6-1.6 1.6H20.5c-.88 0-1.6-.72-1.6-1.6Zm5.5 3.8v4.82h4.2c1.87 0 3.05-.94 3.05-2.64 0-1.7-1.18-2.18-3.05-2.18Z"
+                d="M20 8h14c7.2 0 12 4.16 12 10.52 0 4.74-2.72 8.2-7.38 9.7l7.9 11.78H35.8l-7.38-9.3H28v9.3h-8V8Zm8 7.12v7.32h6.07c2.5 0 4.05-1.3 4.05-3.66 0-2.34-1.55-3.66-4.05-3.66Z"
                 fill="#f8fafc"
             />
-            <path
-                d="M27.7 26.2h2.06c.5 0 .96.26 1.21.68l3.58 6.01H28.5a1.4 1.4 0 0 1-1.15-.61l-2.28-3.34c-.58-.86.1-1.74.63-1.74Z"
-                fill="#38bdf8"
-            />
-            <circle cx="17" cy="17" r="3" fill="#38bdf8" opacity="0.35" />
         </svg>
     );
 }
@@ -167,7 +163,7 @@ export default function SessionReplay({ sessionId }) {
     const [playerMeta, setPlayerMeta] = useState({ totalTime: 0 });
     const [hoveredMarker, setHoveredMarker] = useState(null);
     const [activeEventId, setActiveEventId] = useState(null);
-    const [panelView, setPanelView] = useState("timeline");
+    const [viewMode, setViewMode] = useState("replay");
     const [selectedTraceId, setSelectedTraceId] = useState(null);
     const [collapsedGroups, setCollapsedGroups] = useState({});
 
@@ -175,7 +171,7 @@ export default function SessionReplay({ sessionId }) {
     const clockOffsetRef = useRef(0);
 
     useEffect(() => {
-        setPanelView("timeline");
+        setViewMode("replay");
         setSelectedTraceId(null);
         setShowAll(false);
         setCollapsedGroups({});
@@ -433,8 +429,11 @@ export default function SessionReplay({ sessionId }) {
                 }
                 log("clock offsets", { rrwebFirst: rrwebFirstTsRef.current, tick0: ticks[0]?._t, offset: clockOffsetRef.current });
 
-                const measured = await waitForContainerSize();
-                if (!measured) { setPlayerStatus("error"); warn("no measured size"); return; }
+                let measured = await waitForContainerSize();
+                if (!measured) {
+                    measured = { width: 1280, height: 720 };
+                    warn("no measured size, falling back to", measured);
+                }
                 log("init measured size", measured);
 
                 const rep = new Replayer(initial, {
@@ -672,7 +671,7 @@ export default function SessionReplay({ sessionId }) {
             const matchedTrace = findTraceForEvent(ev);
             if (matchedTrace) {
                 setSelectedTraceId(matchedTrace.id);
-                setPanelView("trace");
+                setViewMode("trace");
             }
         }
     }
@@ -786,28 +785,28 @@ export default function SessionReplay({ sessionId }) {
         return <Icon className={`h-4 w-4 ${className}`} />;
     }
 
+
     const playbackSection = (
-        <section className="flex min-h-0 flex-col rounded-3xl border border-slate-200 bg-white shadow-sm">
-            <div className="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+        <section className="flex min-h-0 flex-1 flex-col bg-white">
+            <div className="flex items-center justify-between border-b border-slate-200 px-8 py-5">
                 <div>
-                    <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-500">Playback</p>
-                    <h2 className="text-lg font-semibold tracking-tight text-slate-900">User session replay</h2>
+                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Playback</p>
+                    <h2 className="text-lg font-semibold tracking-tight text-slate-900">Session replay</h2>
                 </div>
-                <div className="flex items-center gap-3 text-xs text-slate-600">
+                <div className="flex items-center gap-4 text-xs text-slate-600">
                     <span
-                        className={`inline-flex items-center gap-2 rounded-full px-3 py-1 font-medium capitalize ${
+                        className={`flex items-center gap-2 border px-3 py-1 font-medium uppercase tracking-[0.2em] ${
                             playerStatus === "playing"
-                                ? "bg-emerald-100 text-emerald-700"
+                                ? "border-emerald-600 text-emerald-600"
                                 : playerStatus === "paused"
-                                    ? "bg-amber-100 text-amber-700"
+                                    ? "border-amber-600 text-amber-600"
                                     : playerStatus === "loading"
-                                        ? "bg-sky-100 text-sky-700"
+                                        ? "border-sky-600 text-sky-600"
                                         : playerStatus === "error"
-                                            ? "bg-rose-100 text-rose-700"
-                                            : "bg-slate-100 text-slate-600"
+                                            ? "border-rose-600 text-rose-600"
+                                            : "border-slate-400 text-slate-500"
                         }`}
                     >
-                        <span className="h-1.5 w-1.5 rounded-full bg-current" />
                         {playerStatus}
                     </span>
                     <span className="font-medium text-slate-500">
@@ -816,36 +815,33 @@ export default function SessionReplay({ sessionId }) {
                 </div>
             </div>
 
-            <div className="relative flex-1 min-h-0 px-6 pb-6 pt-4">
-                <div
-                    ref={containerRef}
-                    className="h-full w-full overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-inner"
-                />
+            <div className="relative flex-1 min-h-0 bg-slate-100 px-8 py-6">
+                <div ref={containerRef} className="h-full w-full border border-slate-300 bg-white" />
                 {playerStatus === "loading" && (
                     <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-                        <div className="rounded-full border border-slate-200 bg-white/95 px-6 py-3 text-sm text-slate-600 shadow-md">
+                        <div className="border border-slate-300 bg-white px-6 py-3 text-sm text-slate-600">
                             Preparing replay…
                         </div>
                     </div>
                 )}
                 {playerStatus === "error" && (
                     <div className="absolute inset-0 flex items-center justify-center">
-                        <div className="max-w-sm rounded-xl border border-rose-200 bg-rose-50 px-6 py-4 text-sm text-rose-600 shadow-sm">
+                        <div className="border border-rose-400 bg-rose-50 px-6 py-4 text-sm text-rose-700">
                             Unable to load session replay. Please try again.
                         </div>
                     </div>
                 )}
                 {playerStatus === "no-rrweb" && (
                     <div className="absolute inset-0 flex items-center justify-center">
-                        <div className="max-w-sm rounded-xl border border-amber-200 bg-amber-50 px-6 py-4 text-sm text-amber-600 shadow-sm">
+                        <div className="border border-amber-400 bg-amber-50 px-6 py-4 text-sm text-amber-700">
                             No rrweb events (or too few) were captured for this session.
                         </div>
                     </div>
                 )}
             </div>
 
-            <div className="border-t border-slate-200 px-6 py-5">
-                <div className="mb-4 flex items-center gap-3 text-sm text-slate-600">
+            <div className="border-t border-slate-200 bg-white px-8 py-5">
+                <div className="mb-4 flex flex-wrap items-center gap-3 text-sm text-slate-600">
                     <button
                         type="button"
                         onClick={() => {
@@ -865,7 +861,7 @@ export default function SessionReplay({ sessionId }) {
                                 setPlayerStatus("playing");
                             }
                         }}
-                        className="inline-flex items-center gap-2 rounded-full border border-slate-900 bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-white transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 focus:ring-offset-white"
+                        className="inline-flex items-center border border-slate-900 bg-slate-900 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-white transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-sky-500"
                     >
                         <span>{playerStatus === "playing" ? "Pause" : "Play"}</span>
                     </button>
@@ -880,16 +876,16 @@ export default function SessionReplay({ sessionId }) {
                             setPlayerStatus("playing");
                             setCurrentTime(0);
                         }}
-                        className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 focus:ring-offset-white"
+                        className="inline-flex items-center border border-slate-300 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500"
                     >
                         Restart
                     </button>
                     <button
                         type="button"
                         onClick={() => applyFitContain("manual-fit")}
-                        className="ml-2 inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 hover:bg-slate-100"
+                        className="ml-2 inline-flex items-center border border-slate-300 bg-white px-3 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 hover:bg-slate-100"
                     >
-                        Refit Now (log)
+                        Refit now
                     </button>
                     <div className="ml-auto text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
                         {playerStatus === "paused" ? "paused" : "live"}
@@ -898,9 +894,9 @@ export default function SessionReplay({ sessionId }) {
 
                 <div className="relative h-20">
                     <div className="absolute inset-x-0 top-1/2 -translate-y-1/2">
-                        <div className="relative h-2 w-full rounded-full bg-slate-200">
+                        <div className="relative h-2 w-full bg-slate-200">
                             <div
-                                className="absolute inset-y-0 left-0 rounded-full bg-sky-400"
+                                className="absolute inset-y-0 left-0 bg-sky-500"
                                 style={{ width: `${playerMeta.totalTime ? Math.min(100, (currentTime / playerMeta.totalTime) * 100) : 0}%` }}
                             />
                         </div>
@@ -915,7 +911,7 @@ export default function SessionReplay({ sessionId }) {
                                     <button
                                         key={marker.key || marker.position}
                                         type="button"
-                                        className={`pointer-events-auto absolute top-1/2 flex h-8 w-8 -translate-y-1/2 -translate-x-1/2 items-center justify-center rounded-full border border-white text-slate-900 shadow-md transition focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white ${KIND_COLORS[event.kind] || "bg-slate-500"} ${isActive ? "scale-110 ring-2 ring-sky-300" : "hover:scale-110"}`}
+                                        className={`pointer-events-auto absolute top-1/2 flex h-8 w-8 -translate-y-1/2 -translate-x-1/2 items-center justify-center border border-white text-slate-900 transition focus:outline-none focus:ring-2 focus:ring-sky-400 ${KIND_COLORS[event.kind] || "bg-slate-500"} ${isActive ? "ring-2 ring-sky-300" : "hover:opacity-90"}`}
                                         style={{ left: `${marker.position * 100}%` }}
                                         onClick={() => jumpToEvent(event)}
                                         onMouseEnter={() => setHoveredMarker(marker)}
@@ -931,7 +927,7 @@ export default function SessionReplay({ sessionId }) {
                         </div>
 
                         <div
-                            className="absolute top-1/2 z-40 h-4 w-4 -translate-y-1/2 rounded-full border-2 border-sky-400 bg-white shadow-[0_0_0_3px_rgba(56,189,248,0.18)] transition"
+                            className="absolute top-1/2 z-40 h-4 w-4 -translate-y-1/2 border-2 border-sky-400 bg-white"
                             style={{
                                 left: `${playerMeta.totalTime ? Math.min(100, (currentTime / playerMeta.totalTime) * 100) : 0}%`,
                                 transform: "translate(-50%, -50%)",
@@ -963,14 +959,14 @@ export default function SessionReplay({ sessionId }) {
                         const sub = getMarkerMeta(event);
                         return (
                             <div
-                                className="pointer-events-none absolute z-50 -translate-x-1/2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs text-slate-700 shadow-xl"
+                                className="pointer-events-none absolute z-50 -translate-x-1/2 border border-slate-200 bg-white px-3 py-2 text-xs text-slate-700"
                                 style={{ left: `${x}%`, bottom: "calc(50% + 24px)" }}
                             >
                                 <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.25em] text-slate-500">
-                                    <span className={`h-2 w-2 rounded-full ${KIND_COLORS[event.kind] || "bg-slate-500"}`} />
+                                    <span className={`h-2 w-2 ${KIND_COLORS[event.kind] || "bg-slate-500"}`} />
                                     {event.kind}
                                 </div>
-                                <div className="mt-1 text-sm font-medium leading-snug text-slate-900 break-words">{getMarkerTitle(event)}</div>
+                                <div className="mt-1 break-words text-sm font-medium leading-snug text-slate-900">{getMarkerTitle(event)}</div>
                                 {sub && <div className="mt-1 text-[11px] uppercase tracking-[0.3em] text-slate-400">{sub}</div>}
                                 <div className="mt-1 text-[11px] text-slate-500">{formatMaybeTime(alignedSeekMsFor(event))} rrweb • @{event._t ?? "—"}</div>
                             </div>
@@ -982,11 +978,11 @@ export default function SessionReplay({ sessionId }) {
     );
 
     const timelinePanel = (
-        <aside className="flex h-full min-h-0 flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm">
-            <div className="border-b border-slate-200 px-6 py-4">
+        <aside className="flex min-h-0 flex-1 flex-col border-t border-slate-200 bg-white lg:border-l lg:border-t-0">
+            <div className="border-b border-slate-200 px-8 py-4">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                     <div>
-                        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-500">Timeline</p>
+                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Timeline</p>
                         <h2 className="text-sm font-semibold text-slate-900">
                             {showAll ? "All backend events" : "Contextual backend events"}
                         </h2>
@@ -996,20 +992,21 @@ export default function SessionReplay({ sessionId }) {
                             type="checkbox"
                             checked={showAll}
                             onChange={(e) => setShowAll(e.target.checked)}
-                            className="h-4 w-4 rounded border-slate-300 text-sky-500 focus:ring-sky-400"
+                            className="h-4 w-4 border-slate-400 text-sky-600 focus:ring-sky-500"
                         />
                         Show all
                     </label>
                 </div>
             </div>
-            <div className="flex-1 min-h-0 overflow-y-auto px-6 py-6">
+            <div className="flex-1 min-h-0 overflow-y-auto px-8 py-6">
                 {!renderGroups.length && (
-                    <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-center text-xs text-slate-500">
-                        No backend timeline data for this session.
+                    <div className="border border-dashed border-slate-300 bg-slate-100 px-4 py-5 text-xs text-slate-600">
+                        {showAll
+                            ? "No backend timeline data for this session."
+                            : "No events near the current playback time."}
                     </div>
                 )}
-
-                <div className="space-y-5">
+                <div className="space-y-4">
                     {renderGroups.map((g, gi) => {
                         const groupKey = g.id || `group-${gi}`;
                         const isCollapsed = Boolean(collapsedGroups[groupKey]);
@@ -1020,7 +1017,7 @@ export default function SessionReplay({ sessionId }) {
                         const windowLabel = action ? `${formatMaybeTime(startAligned)} → ${formatMaybeTime(endAligned)}` : null;
 
                         return (
-                            <div key={groupKey} className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+                            <div key={groupKey} className="border border-slate-200 bg-white">
                                 <button
                                     type="button"
                                     onClick={() =>
@@ -1031,89 +1028,102 @@ export default function SessionReplay({ sessionId }) {
                                         })
                                     }
                                     aria-expanded={!isCollapsed}
-                                    className="flex w-full items-start justify-between gap-3 border-b border-slate-200 px-4 py-4 text-left transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white"
+                                    className="flex w-full items-start justify-between gap-3 border-b border-slate-200 bg-slate-50 px-4 py-3 text-left transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-400"
                                 >
-                                    <div>
+                                    <div className="space-y-1">
                                         <div className="text-sm font-semibold text-slate-900">{title}</div>
-                                        {windowLabel && <div className="text-xs text-slate-500">{windowLabel}</div>}
+                                        <div className="flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.25em] text-slate-500">
+                                            <span>{g.items.length} events</span>
+                                            {windowLabel && <span>{windowLabel}</span>}
+                                        </div>
                                     </div>
-                                    <div className="flex items-center gap-3 text-[11px] uppercase tracking-[0.25em] text-slate-400">
-                                        <span>{g.items.length} events</span>
-                                        <span aria-hidden className="text-base text-slate-400">{isCollapsed ? "▸" : "▾"}</span>
-                                    </div>
+                                    <span className="text-slate-400">{isCollapsed ? "▸" : "▾"}</span>
                                 </button>
 
                                 {!isCollapsed && (
-                                    <div className="space-y-3 bg-slate-50/70 px-4 py-4">
-                                        {g.items.map((e, i) => {
-                                            const aligned = toRrwebTime(e._t);
-                                            const isActive = activeEventId && e.__key === activeEventId;
-                                            const matchTrace = e.kind === "request" ? findTraceForEvent(e) : null;
-                                            const borderColor = KIND_ACCENT_COLORS[e.kind] || KIND_ACCENT_COLORS.default;
+                                    <div className="divide-y divide-slate-200">
+                                        {g.items.map((e, ei) => {
+                                            const isEventActive = activeEventId && e.__key === activeEventId;
+                                            const eventKey = `${groupKey}-${ei}`;
+                                            const isRequest = e.kind === "request";
+                                            const isDb = e.kind === "db";
+                                            const isEmail = e.kind === "email";
+                                            const isAction = e.kind === "action";
 
                                             return (
                                                 <button
-                                                    key={e.__key || i}
-                                                    id={e.__key ? `event-${e.__key}` : undefined}
+                                                    id={`event-${e.__key}`}
+                                                    key={eventKey}
                                                     type="button"
                                                     onClick={() => jumpToEvent(e)}
-                                                    className={`group relative w-full rounded-2xl border border-slate-100 border-l-[4px] bg-white px-5 py-4 text-left text-sm transition focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white ${
-                                                        isActive ? "border-sky-200 bg-sky-50 shadow-sm" : "hover:border-slate-200 hover:bg-slate-50"
+                                                    className={`flex w-full flex-col gap-3 px-4 py-3 text-left transition ${
+                                                        isEventActive ? "bg-slate-100" : "hover:bg-slate-50"
                                                     }`}
-                                                    style={{ borderLeftColor: borderColor }}
                                                 >
-                                                    <div className="flex flex-col gap-3">
-                                                        <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.25em] text-slate-500">
-                                                            <span className="flex items-center gap-2">
-                                                                <span className={`h-2 w-2 rounded-full ${KIND_COLORS[e.kind] || "bg-slate-500"}`} />
-                                                                {e.kind}
-                                                            </span>
-                                                            <span>
-                                                                @{e._t ?? "—"} • {typeof aligned === "number" ? `${Math.round(aligned)}ms` : "—"}
-                                                            </span>
+                                                    <div className="flex items-start justify-between gap-4">
+                                                        <div className="flex items-center gap-3">
+                                                            <span className={`h-2 w-2 ${KIND_COLORS[e.kind] || "bg-slate-500"}`} />
+                                                            <div>
+                                                                <div className="text-sm font-semibold text-slate-900">{getMarkerTitle(e)}</div>
+                                                                <div className="mt-1 text-[11px] uppercase tracking-[0.28em] text-slate-400">{e.kind}</div>
+                                                            </div>
                                                         </div>
-
-                                                        {e.kind === "request" && (
-                                                            <div className="space-y-1 text-xs text-slate-600">
-                                                                <div className="font-mono text-xs text-slate-900">
-                                                                    {e.meta?.method} {e.meta?.url}
-                                                                </div>
-                                                                <div className="flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.25em] text-slate-400">
-                                                                    <span>Status {e.meta?.status ?? "—"}</span>
-                                                                    <span>{e.meta?.durMs != null ? `${e.meta?.durMs}ms` : "—"}</span>
-                                                                    {matchTrace && <span className="text-sky-600">Trace available</span>}
-                                                                </div>
-                                                            </div>
-                                                        )}
-                                                        {e.kind === "db" && (
-                                                            <div className="space-y-2 text-xs text-slate-600">
-                                                                <div className="font-mono text-[11px] uppercase tracking-[0.2em] text-slate-500">
-                                                                    {e.meta?.collection} • {e.meta?.op}
-                                                                </div>
-                                                                {e.meta?.query && (
-                                                                    <pre className="max-h-36 overflow-auto rounded-lg border border-slate-200 bg-slate-100 p-3 text-[11px] leading-relaxed text-slate-700">
-                                                                        {JSON.stringify(e.meta.query, null, 2)}
-                                                                    </pre>
-                                                                )}
-                                                                {e.meta?.resultMeta && (
-                                                                    <div className="text-[11px] text-slate-500">result {JSON.stringify(e.meta.resultMeta)}</div>
-                                                                )}
-                                                            </div>
-                                                        )}
-                                                        {e.kind === "action" && (
-                                                            <div className="space-y-1 text-xs text-slate-600">
-                                                                <div className="font-mono text-sm text-slate-900">{e.label || e.actionId}</div>
-                                                                {(typeof e.tStart === "number" || typeof e.tEnd === "number") && (
-                                                                    <div className="text-[11px] text-slate-500">[{e.tStart ?? "—"} … {e.tEnd ?? "—"}]</div>
-                                                                )}
-                                                            </div>
-                                                        )}
-                                                        {e.kind === "email" && (
-                                                            <div className="text-xs text-slate-600">
-                                                                <EmailItem meta={e.meta} />
-                                                            </div>
-                                                        )}
+                                                        <div className="text-right text-xs text-slate-500">
+                                                            <div>{formatMaybeTime(alignedSeekMsFor(e))}</div>
+                                                            {typeof e._t === "number" && <div className="font-mono text-[11px] text-slate-400">@{e._t}</div>}
+                                                        </div>
                                                     </div>
+
+                                                    {isRequest && (
+                                                        <div className="space-y-2 text-xs text-slate-600">
+                                                            <div className="font-mono text-sm text-slate-900">
+                                                                {e.meta?.method} {e.meta?.url}
+                                                            </div>
+                                                            <div className="flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.28em] text-slate-500">
+                                                                {e.meta?.status != null && <span>Status {e.meta.status}</span>}
+                                                                {e.meta?.durMs != null && <span>{e.meta.durMs}ms</span>}
+                                                                {typeof e.meta?.size === "number" && <span>{e.meta.size} bytes</span>}
+                                                            </div>
+                                                            {e.meta?.body && (
+                                                                <pre className="max-h-40 overflow-auto border border-slate-300 bg-slate-100 p-3 text-[11px] leading-relaxed text-slate-700">
+                                                                    {JSON.stringify(e.meta.body, null, 2)}
+                                                                </pre>
+                                                            )}
+                                                            {e.meta?.response && (
+                                                                <pre className="max-h-40 overflow-auto border border-slate-300 bg-slate-100 p-3 text-[11px] leading-relaxed text-slate-700">
+                                                                    {JSON.stringify(e.meta.response, null, 2)}
+                                                                </pre>
+                                                            )}
+                                                        </div>
+                                                    )}
+                                                    {isDb && (
+                                                        <div className="space-y-2 text-xs text-slate-600">
+                                                            <div className="font-mono text-sm text-slate-900">
+                                                                {e.meta?.collection} • {e.meta?.op}
+                                                            </div>
+                                                            {e.meta?.query && (
+                                                                <pre className="max-h-36 overflow-auto border border-slate-300 bg-slate-100 p-3 text-[11px] leading-relaxed text-slate-700">
+                                                                    {JSON.stringify(e.meta.query, null, 2)}
+                                                                </pre>
+                                                            )}
+                                                            {e.meta?.resultMeta && (
+                                                                <div className="text-[11px] text-slate-500">result {JSON.stringify(e.meta.resultMeta)}</div>
+                                                            )}
+                                                        </div>
+                                                    )}
+                                                    {isAction && (
+                                                        <div className="space-y-1 text-xs text-slate-600">
+                                                            <div className="font-mono text-sm text-slate-900">{e.label || e.actionId}</div>
+                                                            {(typeof e.tStart === "number" || typeof e.tEnd === "number") && (
+                                                                <div className="text-[11px] text-slate-500">[{e.tStart ?? "—"} … {e.tEnd ?? "—"}]</div>
+                                                            )}
+                                                        </div>
+                                                    )}
+                                                    {isEmail && (
+                                                        <div className="text-xs text-slate-600">
+                                                            <EmailItem meta={e.meta} />
+                                                        </div>
+                                                    )}
                                                 </button>
                                             );
                                         })}
@@ -1122,57 +1132,54 @@ export default function SessionReplay({ sessionId }) {
                             </div>
                         );
                     })}
-
-                    {!renderGroups.length && !showAll && (
-                        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-500">
-                            No events near the current time. Try <button className="font-medium text-sky-600 underline" onClick={() => setShowAll(true)}>showing all</button>.
-                        </div>
-                    )}
                 </div>
             </div>
         </aside>
     );
 
-    const tracePanel = (
-        <aside className="flex h-full min-h-0 flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm">
-            <div className="border-b border-slate-200 px-6 py-4">
+    const tracePanelContent = (
+        <>
+            <div className="border-b border-slate-200 px-8 py-4">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                     <div>
-                        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-500">Function trace</p>
+                        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Function traces</p>
                         <h2 className="text-sm font-semibold text-slate-900">{traceTitle}</h2>
                     </div>
                     <span className="text-[11px] uppercase tracking-[0.25em] text-slate-500">{traceSummaryText}</span>
                 </div>
-                <p className="mt-2 text-xs text-slate-500">Select a request to explore its captured function trace.</p>
+                <p className="mt-2 text-xs text-slate-500">Select a request to inspect its captured trace.</p>
             </div>
-            <div className="flex-1 min-h-0 overflow-y-auto px-6 py-6">
-                <div className="flex h-full min-h-0 flex-col gap-4">
+            <div className="flex-1 min-h-0 overflow-y-auto px-8 py-6">
+                <div className="flex min-h-0 flex-1 flex-col gap-4">
                     {traceStatus === "loading" && !traceEntries.length && (
-                        <div className="flex flex-1 items-center justify-center rounded-2xl border border-slate-200 bg-slate-50">
-                            <div className="animate-pulse text-xs text-slate-500">Fetching trace data…</div>
-                        </div>
+                        <div className="border border-slate-200 bg-slate-100 px-4 py-4 text-xs text-slate-600">Fetching trace data…</div>
                     )}
                     {traceStatus === "error" && !traceEntries.length && (
-                        <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-xs text-rose-600">Unable to load traces for this session.</div>
+                        <div className="border border-rose-400 bg-rose-50 px-4 py-4 text-xs text-rose-700">Unable to load traces for this session.</div>
                     )}
                     {traceStatus === "ready" && !traceEntries.length && (
-                        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-600">No function traces were captured for this session.</div>
+                        <div className="border border-slate-200 bg-slate-100 px-4 py-4 text-xs text-slate-600">No function traces were captured for this session.</div>
                     )}
                     {traceStatus === "idle" && !traceEntries.length && (
-                        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-600">Traces will appear once data is collected for this session.</div>
+                        <div className="border border-slate-200 bg-slate-100 px-4 py-4 text-xs text-slate-600">Traces will appear once data is collected for this session.</div>
                     )}
                     {traceEntries.length > 0 && (
-                        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pr-1">
+                        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
                             {traceEntries.map((entry) => {
                                 const isActive = selectedTrace?.id === entry.id;
                                 const meta = entry.request || {};
                                 const label = entry.label || meta.method || entry.id;
                                 return (
-                                    <div key={entry.id} className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+                                    <div key={entry.id} className="border border-slate-200 bg-white">
                                         <button
                                             type="button"
-                                            onClick={() => setSelectedTraceId(entry.id)}
-                                            className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white"
+                                            onClick={() => {
+                                                setSelectedTraceId(entry.id);
+                                                setViewMode("trace");
+                                            }}
+                                            className={`flex w-full items-center justify-between gap-4 px-4 py-3 text-left transition ${
+                                                isActive ? "bg-slate-100" : "bg-white hover:bg-slate-50"
+                                            }`}
                                         >
                                             <div>
                                                 <div className="text-sm font-semibold text-slate-900">{label}</div>
@@ -1185,7 +1192,7 @@ export default function SessionReplay({ sessionId }) {
                                             <span className="text-slate-400">{isActive ? "▾" : "▸"}</span>
                                         </button>
                                         {isActive && (
-                                            <div className="border-t border-slate-200 bg-slate-50 px-2 py-4 sm:px-4">
+                                            <div className="border-t border-slate-200 bg-slate-50 px-4 py-4">
                                                 <FunctionTraceViewer trace={selectedTrace?.events || []} title={traceTitle} className="is-embedded" />
                                             </div>
                                         )}
@@ -1196,73 +1203,72 @@ export default function SessionReplay({ sessionId }) {
                     )}
                 </div>
             </div>
-        </aside>
+        </>
+    );
+
+    const traceFullView = (
+        <section className="flex min-h-0 flex-1 flex-col border-t border-slate-200 bg-white">
+            {tracePanelContent}
+        </section>
     );
 
     return (
-        <div className="min-h-screen bg-slate-100 text-slate-900">
-            <div className="mx-auto flex min-h-screen max-w-7xl flex-col gap-6 px-6 py-8 lg:px-10">
-                <header className="flex flex-col gap-4 border-b border-slate-200 pb-6">
+        <div className="flex min-h-screen flex-col bg-slate-100 text-slate-900">
+            <header className="border-b border-slate-200 bg-white px-8 py-5">
+                <div className="flex flex-wrap items-center justify-between gap-4">
                     <div className="flex items-center gap-4">
-                        <LogoMark className="h-11 w-11" />
+                        <LogoMark className="h-10 w-10" />
                         <div>
                             <p className="text-xs font-semibold uppercase tracking-[0.4em] text-slate-500">Replay console</p>
                             <h1 className="text-2xl font-semibold tracking-tight text-slate-900">Session debugger</h1>
                         </div>
                     </div>
-                    <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500">
-                        <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1 font-medium uppercase tracking-[0.3em] text-slate-600">
-                            Session
-                            <span className="font-mono text-slate-900">{sessionId}</span>
-                        </span>
-                        <span className="text-slate-500">
-                            Inspect the rrweb playback alongside backend events and captured traces.
-                        </span>
-                    </div>
-                </header>
-
-                <div className="grid flex-1 min-h-0 gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
-                    <div className="flex min-h-0 flex-col gap-6">
-                        {playbackSection}
-                    </div>
-
-                    <div className="flex min-h-0 flex-col gap-4">
-                        <div className="flex items-center justify-between gap-3 rounded-3xl border border-slate-200 bg-white px-4 py-3 shadow-sm">
-                            <nav className="flex flex-wrap items-center gap-2">
-                                <button
-                                    type="button"
-                                    onClick={() => setPanelView("timeline")}
-                                    className={`inline-flex items-center rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] transition focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white ${
-                                        panelView === "timeline"
-                                            ? "bg-slate-900 text-white shadow-sm"
-                                            : "border border-slate-200 bg-white text-slate-600 hover:bg-slate-100"
-                                    }`}
-                                >
-                                    Timeline
-                                </button>
-                                <button
-                                    type="button"
-                                    onClick={() => setPanelView("trace")}
-                                    className={`inline-flex items-center rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] transition focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white ${
-                                        panelView === "trace"
-                                            ? "bg-slate-900 text-white shadow-sm"
-                                            : "border border-slate-200 bg-white text-slate-600 hover:bg-slate-100"
-                                    }`}
-                                >
-                                    Function trace
-                                </button>
-                            </nav>
-                            <span className="text-[11px] uppercase tracking-[0.25em] text-slate-400">
-                                {panelView === "timeline" ? timelineSummaryText : traceSummaryText}
-                            </span>
-                        </div>
-
-                        <div className="flex min-h-0 flex-1">
-                            {panelView === "timeline" ? timelinePanel : tracePanel}
-                        </div>
+                    <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.25em]">
+                        <button
+                            type="button"
+                            onClick={() => setViewMode("replay")}
+                            className={`border px-4 py-2 ${
+                                viewMode === "replay"
+                                    ? "border-slate-900 bg-slate-900 text-white"
+                                    : "border-slate-300 bg-white text-slate-600 hover:bg-slate-100"
+                            }`}
+                        >
+                            Replay
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => setViewMode("trace")}
+                            className={`border px-4 py-2 ${
+                                viewMode === "trace"
+                                    ? "border-slate-900 bg-slate-900 text-white"
+                                    : "border-slate-300 bg-white text-slate-600 hover:bg-slate-100"
+                            }`}
+                        >
+                            Function traces
+                        </button>
                     </div>
                 </div>
-            </div>
+                <div className="mt-3 flex flex-wrap items-center gap-4 text-xs text-slate-600">
+                    <span className="font-mono text-slate-800">Session {sessionId || "—"}</span>
+                    <span>{viewMode === "replay" ? timelineSummaryText : traceSummaryText}</span>
+                </div>
+            </header>
+            <main className="flex flex-1 min-h-0 flex-col">
+                {viewMode === "replay" ? (
+                    <div className="flex flex-1 min-h-0 flex-col lg:flex-row">
+                        <div className="flex min-h-0 flex-1 flex-col">
+                            {playbackSection}
+                        </div>
+                        <div className="flex min-h-0 flex-col lg:w-[28rem] lg:flex-none">
+                            {timelinePanel}
+                        </div>
+                    </div>
+                ) : (
+                    <div className="flex flex-1 min-h-0 flex-col">
+                        {traceFullView}
+                    </div>
+                )}
+            </main>
         </div>
     );
 }

--- a/src/pages/SessionReplay.jsx
+++ b/src/pages/SessionReplay.jsx
@@ -31,15 +31,24 @@ function LogoMark({ className = "", ...props }) {
         >
             <defs>
                 <linearGradient id="replay-logo-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                    <stop offset="0%" stopColor="#38bdf8" />
-                    <stop offset="100%" stopColor="#a855f7" />
+                    <stop offset="0%" stopColor="#60a5fa" />
+                    <stop offset="55%" stopColor="#7dd3fc" />
+                    <stop offset="100%" stopColor="#c084fc" />
+                </linearGradient>
+                <linearGradient id="replay-logo-accent" x1="20%" y1="20%" x2="85%" y2="90%">
+                    <stop offset="0%" stopColor="#0f172a" stopOpacity="0.95" />
+                    <stop offset="100%" stopColor="#1e293b" stopOpacity="0.88" />
                 </linearGradient>
             </defs>
             <rect x="2" y="2" width="44" height="44" rx="14" fill="url(#replay-logo-gradient)" />
             <path
-                d="M16 12h10.2c6.1 0 10.8 3.7 10.8 9.8 0 4-1.8 6.8-5.1 8.6l5.3 9.6h-7.3l-4.2-8.2h-4.7v8.2H16V12zm6 6v6.3h4.2c2.2 0 3.5-1.2 3.5-3.2 0-2-1.3-3.1-3.5-3.1H22z"
-                fill="#0f172a"
-                fillOpacity="0.92"
+                d="M17 13.5c0-.83.67-1.5 1.5-1.5h8.4c5.65 0 9.6 3.27 9.6 8.45 0 3.87-1.92 6.54-5.25 7.65l4.98 8.98c.52.93-.16 2.07-1.2 2.07H29.6c-.57 0-1.08-.31-1.34-.8l-4.06-7.7h-2.2v7c0 .83-.67 1.5-1.5 1.5H18.5c-.83 0-1.5-.67-1.5-1.5V13.5Zm5.5 3.9v5.7h3.75c1.68 0 2.75-.92 2.75-2.7 0-1.77-1.07-3-2.75-3h-3.75Z"
+                fill="url(#replay-logo-accent)"
+            />
+            <path
+                d="M27.8 27.8h2.34a1.5 1.5 0 0 1 1.31.78l3.92 7.3H29.9a1.5 1.5 0 0 1-1.32-.79l-2.58-4.9c-.45-.87.18-1.94 1.16-1.94Z"
+                fill="#1d4ed8"
+                fillOpacity="0.55"
             />
         </svg>
     );
@@ -687,49 +696,59 @@ export default function SessionReplay({ sessionId }) {
     }
 
     return (
-        <div className="min-h-screen bg-slate-950 text-slate-100">
+        <div className="min-h-screen bg-slate-900 text-slate-100">
             <div className="relative flex min-h-screen flex-col overflow-hidden">
                 <div className="pointer-events-none absolute inset-0">
-                    <div className="absolute -left-32 top-0 h-80 w-80 rounded-full bg-sky-500/20 blur-3xl" />
-                    <div className="absolute bottom-[-18%] right-[-12%] h-96 w-96 rounded-full bg-fuchsia-500/12 blur-[150px]" />
+                    <div className="absolute -left-28 top-[-8%] h-80 w-80 rounded-full bg-sky-400/30 blur-3xl" />
+                    <div className="absolute bottom-[-18%] right-[-12%] h-96 w-96 rounded-full bg-fuchsia-400/20 blur-[150px]" />
                 </div>
                 <header className="relative z-10 flex flex-wrap items-center justify-between gap-6 px-8 py-6 sm:px-12">
                     <div className="flex items-center gap-4">
                         <LogoMark className="h-12 w-12 drop-shadow-xl" />
                         <div>
-                            <p className="text-xs uppercase tracking-[0.4em] text-slate-500">Replay console</p>
-                            <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">Session {sessionId ?? "—"}</h1>
+                            <p className="text-xs uppercase tracking-[0.4em] text-slate-300">Replay console</p>
+                            <h1 className="text-2xl font-semibold tracking-tight text-slate-50 sm:text-3xl">Session {sessionId ?? "—"}</h1>
                         </div>
                     </div>
-                    <div className="flex flex-wrap items-center gap-4 text-xs uppercase tracking-[0.25em] text-slate-400">
-                        <div className="inline-flex rounded-full border border-slate-800/70 bg-slate-900/60 p-1 shadow-lg backdrop-blur">
+                    <div className="flex flex-wrap items-center gap-4 text-xs uppercase tracking-[0.25em] text-slate-300">
+                        <div className="inline-flex rounded-full border border-slate-600/60 bg-slate-800/60 p-1 shadow-lg backdrop-blur">
                             <button
                                 type="button"
                                 onClick={() => setPanelView("timeline")}
-                                className={`rounded-full px-4 py-2 font-semibold transition ${panelView === "timeline" ? "bg-slate-800/60 text-slate-100" : "text-slate-400 hover:text-slate-200"}`}
+                                className={`rounded-full px-4 py-2 font-semibold transition ${panelView === "timeline" ? "bg-slate-700/60 text-slate-100" : "text-slate-300 hover:text-slate-100"}`}
                             >
                                 Timeline
                             </button>
                             <button
                                 type="button"
                                 onClick={() => setPanelView("trace")}
-                                className={`rounded-full px-4 py-2 font-semibold transition ${panelView === "trace" ? "bg-slate-800/60 text-slate-100" : "text-slate-400 hover:text-slate-200"}`}
+                                className={`rounded-full px-4 py-2 font-semibold transition ${panelView === "trace" ? "bg-slate-700/60 text-slate-100" : "text-slate-300 hover:text-slate-100"}`}
                             >
                                 Function trace
                             </button>
                         </div>
-                        <span className="text-[11px] uppercase tracking-[0.3em] text-slate-500">{traceSummaryText}</span>
+                        <span className="text-[11px] uppercase tracking-[0.3em] text-slate-300">{traceSummaryText}</span>
                     </div>
                 </header>
                 <div className="relative z-10 flex flex-1 flex-col">
-                    <div className="grid flex-1 grid-cols-[minmax(0,1.65fr)_minmax(0,1.05fr)] overflow-hidden">
-                <section className="flex min-h-0 flex-col border-r border-slate-900/60 bg-slate-950/80 backdrop-blur">
-                    <div className="flex items-center justify-between border-b border-slate-900/60 px-6 py-4">
-                        <div>
-                            <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Playback</p>
-                            <h2 className="text-lg font-semibold tracking-tight">User session replay</h2>
-                        </div>
-                        <div className="flex items-center gap-3 text-xs text-slate-400">
+                    <div
+                        className={`grid min-h-0 flex-1 overflow-hidden ${
+                            panelView === "trace"
+                                ? "grid-cols-1"
+                                : "grid-cols-[minmax(0,1.65fr)_minmax(0,1.05fr)]"
+                        }`}
+                    >
+                        <section
+                            className={`flex min-h-0 flex-col border-r border-slate-800/60 bg-slate-900/80 backdrop-blur ${
+                                panelView === "trace" ? "hidden" : ""
+                            }`}
+                        >
+                            <div className="flex items-center justify-between border-b border-slate-800/50 px-6 py-4">
+                                <div>
+                                    <p className="text-xs uppercase tracking-[0.3em] text-slate-300">Playback</p>
+                                    <h2 className="text-lg font-semibold tracking-tight text-slate-100">User session replay</h2>
+                                </div>
+                                <div className="flex items-center gap-3 text-xs text-slate-300">
               <span className={`inline-flex items-center gap-1 rounded-full px-3 py-1 font-medium ${
                   playerStatus === "playing" ? "bg-emerald-500/10 text-emerald-300" :
                       playerStatus === "paused" ? "bg-amber-500/10 text-amber-300" :
@@ -746,7 +765,7 @@ export default function SessionReplay({ sessionId }) {
                     <div className="relative flex-1 min-h-0 px-6 pb-6 pt-4">
                         <div
                             ref={containerRef}
-                            className="h-full w-full overflow-hidden rounded-2xl border border-slate-900/40 bg-slate-900/80 shadow-2xl"
+                            className="h-full w-full overflow-hidden rounded-2xl border border-slate-800/40 bg-slate-900/75 shadow-2xl"
                         />
                         {playerStatus === "loading" && (
                             <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
@@ -771,7 +790,7 @@ export default function SessionReplay({ sessionId }) {
                         )}
                     </div>
 
-                    <div className="border-t border-slate-900/60 bg-slate-950/90 px-6 py-5">
+                    <div className="border-t border-slate-800/60 bg-slate-900/85 px-6 py-5">
                         <div className="mb-4 flex items-center gap-3 text-sm">
                             <button
                                 type="button"
@@ -793,7 +812,7 @@ export default function SessionReplay({ sessionId }) {
                                 }}
                                 className="inline-flex items-center gap-2 rounded-full border border-slate-800/60 bg-slate-900 px-4 py-2 font-medium text-slate-100 transition hover:border-slate-700 hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-sky-500"
                             >
-                <span className="text-xs uppercase tracking-[0.2em] text-slate-400">
+                <span className="text-xs uppercase tracking-[0.2em] text-slate-300">
                   {playerStatus === "playing" ? "Pause" : "Play"}
                 </span>
                             </button>
@@ -808,18 +827,18 @@ export default function SessionReplay({ sessionId }) {
                                     setPlayerStatus("playing");
                                     setCurrentTime(0);
                                 }}
-                                className="inline-flex items-center gap-2 rounded-full border border-slate-800/60 bg-slate-900 px-4 py-2 text-xs uppercase tracking-[0.2em] text-slate-400 transition hover:border-slate-700 hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-sky-500"
+                                className="inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900 px-4 py-2 text-xs uppercase tracking-[0.2em] text-slate-300 transition hover:border-slate-600 hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-sky-500"
                             >
                                 Restart
                             </button>
                             <button
                                 type="button"
                                 onClick={() => applyFitContain("manual-fit")}
-                                className="ml-2 inline-flex items-center gap-2 rounded-full border border-slate-800/60 bg-slate-900 px-3 py-2 text-xs uppercase tracking-[0.2em] text-slate-400"
+                                className="ml-2 inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900 px-3 py-2 text-xs uppercase tracking-[0.2em] text-slate-300"
                             >
                                 Refit Now (log)
                             </button>
-                            <div className="ml-auto text-xs text-slate-400">
+                            <div className="ml-auto text-xs text-slate-300">
                                 {playerStatus === "paused" ? "paused" : "live"}
                             </div>
                         </div>
@@ -898,10 +917,10 @@ export default function SessionReplay({ sessionId }) {
                                 const sub = getMarkerMeta(event);
                                 return (
                                     <div
-                                        className="pointer-events-none absolute z-50 -translate-x-1/2 rounded-xl border border-slate-900/60 bg-slate-950/95 px-3 py-2 text-xs text-slate-200 shadow-2xl backdrop-blur"
+                                        className="pointer-events-none absolute z-50 -translate-x-1/2 rounded-xl border border-slate-800/60 bg-slate-900/95 px-3 py-2 text-xs text-slate-100 shadow-2xl backdrop-blur"
                                         style={{ left: `${x}%`, bottom: "calc(50% + 24px)" }}
                                     >
-                                        <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.25em] text-slate-500">
+                                        <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.25em] text-slate-300">
                                             <span className={`h-2 w-2 rounded-full ${KIND_COLORS[event.kind] || "bg-slate-500"}`} />
                                             {event.kind}
                                         </div>
@@ -909,11 +928,11 @@ export default function SessionReplay({ sessionId }) {
                                             {getMarkerTitle(event)}
                                         </div>
                                         {sub && (
-                                            <div className="mt-1 text-[11px] uppercase tracking-[0.3em] text-slate-500">
+                                            <div className="mt-1 text-[11px] uppercase tracking-[0.3em] text-slate-300">
                                                 {sub}
                                             </div>
                                         )}
-                                        <div className="mt-1 text-[11px] text-slate-500">
+                                        <div className="mt-1 text-[11px] text-slate-300">
                                             {formatMaybeTime(alignedSeekMsFor(event))} rrweb • @{event._t ?? "—"}
                                         </div>
                                     </div>
@@ -923,33 +942,37 @@ export default function SessionReplay({ sessionId }) {
                     </div>
                 </section>
 
-                <aside className="flex h-full min-h-0 flex-col overflow-hidden bg-slate-950/85 backdrop-blur">
-                    <div className="border-b border-slate-900/60 px-6 py-4">
+                <aside
+                    className={`flex h-full min-h-0 flex-col overflow-hidden backdrop-blur ${
+                        panelView === "trace" ? "bg-slate-900/80" : "bg-slate-900/70"
+                    }`}
+                >
+                    <div className="border-b border-slate-800/50 px-6 py-4">
                         <div className="flex flex-wrap items-center justify-between gap-3">
                             <div>
-                                <p className="text-xs uppercase tracking-[0.3em] text-slate-500">{panelView === "timeline" ? "Timeline" : "Function trace"}</p>
-                                <h2 className="text-sm font-semibold text-slate-200">
+                                <p className="text-xs uppercase tracking-[0.3em] text-slate-300">{panelView === "timeline" ? "Timeline" : "Function trace"}</p>
+                                <h2 className="text-sm font-semibold text-slate-100">
                                     {panelView === "timeline"
                                         ? showAll ? "All backend events" : "Contextual backend events"
                                         : traceTitle}
                                 </h2>
                             </div>
                             {panelView === "timeline" ? (
-                                <label className="flex items-center gap-2 text-[11px] uppercase tracking-[0.2em] text-slate-500">
+                                <label className="flex items-center gap-2 text-[11px] uppercase tracking-[0.2em] text-slate-300">
                                     <input
                                         type="checkbox"
                                         checked={showAll}
                                         onChange={(e) => setShowAll(e.target.checked)}
-                                        className="h-4 w-4 rounded border-slate-700 bg-slate-900 text-sky-400 focus:ring-sky-500"
+                                        className="h-4 w-4 rounded border-slate-600 bg-slate-900 text-sky-400 focus:ring-sky-400"
                                     />
                                     Show all
                                 </label>
                             ) : (
-                                <span className="text-[11px] uppercase tracking-[0.25em] text-slate-500">{traceSummaryText}</span>
+                                <span className="text-[11px] uppercase tracking-[0.25em] text-slate-300">{traceSummaryText}</span>
                             )}
                         </div>
                         {panelView === "trace" && (
-                            <p className="mt-2 text-xs text-slate-500">
+                            <p className="mt-2 text-xs text-slate-300">
                                 Select a request to explore its captured function trace.
                             </p>
                         )}
@@ -957,7 +980,7 @@ export default function SessionReplay({ sessionId }) {
 
                     <div className={`flex-1 overflow-y-auto px-6 py-6 min-h-0 ${panelView !== "timeline" ? "hidden" : ""}`}>
                         {!renderGroups.length && (
-                            <div className="text-xs text-slate-500">
+                            <div className="text-xs text-slate-300">
                                 No backend timeline data for this session.
                             </div>
                         )}
@@ -973,16 +996,16 @@ export default function SessionReplay({ sessionId }) {
                                 return (
                                     <div
                                         key={g.id || gi}
-                                        className="rounded-2xl border border-slate-900/60 bg-slate-900/70 shadow-lg backdrop-blur"
+                                        className="rounded-2xl border border-slate-800/50 bg-slate-900/65 shadow-lg backdrop-blur"
                                     >
-                                        <div className="flex items-center justify-between border-b border-slate-900/60 px-4 py-3">
+                                        <div className="flex items-center justify-between border-b border-slate-800/50 px-4 py-3">
                                             <div>
                                                 <div className="text-sm font-semibold text-slate-100">{title}</div>
                                                 {windowLabel && (
-                                                    <div className="text-xs text-slate-500">{windowLabel}</div>
+                                                    <div className="text-xs text-slate-300">{windowLabel}</div>
                                                 )}
                                             </div>
-                                            <div className="text-[11px] uppercase tracking-[0.25em] text-slate-500">
+                                            <div className="text-[11px] uppercase tracking-[0.25em] text-slate-300">
                                                 {g.items.length} events
                                             </div>
                                         </div>
@@ -1002,14 +1025,14 @@ export default function SessionReplay({ sessionId }) {
                                                         className={`group relative overflow-hidden rounded-xl border px-3 py-3 text-sm transition focus:outline-none focus:ring-2 focus:ring-sky-500 ${
                                                             isActive
                                                                 ? "border-sky-500/60 bg-sky-500/10"
-                                                                : "border-slate-800/60 bg-slate-950/40 hover:border-slate-700 hover:bg-slate-900/60"
+                                                                : "border-slate-700/50 bg-slate-900/45 hover:border-slate-600 hover:bg-slate-900/65"
                                                         }`}
                                                     >
-                                                        <div className="mb-2 flex items-center justify-between text-[11px] uppercase tracking-[0.25em] text-slate-500">
-                              <span className="flex items-center gap-2">
-                                <span className={`h-2 w-2 rounded-full ${KIND_COLORS[e.kind] || "bg-slate-500"}`} />
-                                  {e.kind}
-                              </span>
+                                                        <div className="mb-2 flex items-center justify-between text-[11px] uppercase tracking-[0.25em] text-slate-300">
+                                                            <span className="flex items-center gap-2">
+                                                                <span className={`h-2 w-2 rounded-full ${KIND_COLORS[e.kind] || "bg-slate-500"}`} />
+                                                                {e.kind}
+                                                            </span>
                                                             <span>
                                 @{e._t ?? "—"} • {typeof aligned === "number" ? `${Math.round(aligned)}ms` : "—"}
                               </span>
@@ -1017,43 +1040,43 @@ export default function SessionReplay({ sessionId }) {
 
                                                         {e.kind === "request" && (
                                                             <div className="space-y-1">
-                                                                <div className="font-mono text-xs text-slate-200">
+                                                                <div className="font-mono text-xs text-slate-100">
                                                                     {e.meta?.method} {e.meta?.url}
                                                                 </div>
-                                                                <div className="text-xs text-slate-400">
+                                                                <div className="text-xs text-slate-300">
                                                                     status {e.meta?.status} • {e.meta?.durMs}ms
                                                                 </div>
                                                             </div>
                                                         )}
                                                         {e.kind === "db" && (
                                                             <div className="space-y-2 text-xs text-slate-300">
-                                                                <div className="font-mono text-[11px] uppercase tracking-[0.2em] text-slate-400">
+                                                                <div className="font-mono text-[11px] uppercase tracking-[0.2em] text-slate-300">
                                                                     {e.meta?.collection} • {e.meta?.op}
                                                                 </div>
                                                                 {e.meta?.query && (
-                                                                    <pre className="max-h-36 overflow-auto rounded-lg bg-slate-950/70 p-3 text-[11px] leading-relaxed text-slate-300">
-                                    {JSON.stringify(e.meta.query, null, 2)}
-                                  </pre>
+                                                                    <pre className="max-h-36 overflow-auto rounded-lg bg-slate-900/70 p-3 text-[11px] leading-relaxed text-slate-200">
+                                                                        {JSON.stringify(e.meta.query, null, 2)}
+                                                                    </pre>
                                                                 )}
                                                                 {e.meta?.resultMeta && (
-                                                                    <div className="text-[11px] text-slate-400">
+                                                                    <div className="text-[11px] text-slate-300">
                                                                         result {JSON.stringify(e.meta.resultMeta)}
                                                                     </div>
                                                                 )}
                                                             </div>
                                                         )}
                                                         {e.kind === "action" && (
-                                                            <div className="space-y-1 text-xs text-slate-200">
+                                                            <div className="space-y-1 text-xs text-slate-100">
                                                                 <div className="font-mono text-sm">{e.label || e.actionId}</div>
                                                                 {(typeof e.tStart === "number" || typeof e.tEnd === "number") && (
-                                                                    <div className="text-[11px] text-slate-400">
+                                                                    <div className="text-[11px] text-slate-300">
                                                                         [{e.tStart ?? "—"} … {e.tEnd ?? "—"}]
                                                                     </div>
                                                                 )}
                                                             </div>
                                                         )}
                                                         {e.kind === "email" && (
-                                                            <div className="text-xs text-slate-200">
+                                                            <div className="text-xs text-slate-100">
                                                                 <EmailItem meta={e.meta} />
                                                             </div>
                                                         )}
@@ -1066,7 +1089,7 @@ export default function SessionReplay({ sessionId }) {
                             })}
 
                             {!renderGroups.length && !showAll && (
-                                <div className="rounded-XL border border-slate-900/60 bg-slate-900/70 px-4 py-3 text-xs text-slate-400">
+                                <div className="rounded-XL border border-slate-800/50 bg-slate-900/60 px-4 py-3 text-xs text-slate-300">
                                     No events near the current time. Try{" "}
                                     <button className="text-sky-400 underline" onClick={() => setShowAll(true)}>
                                         showing all
@@ -1080,22 +1103,22 @@ export default function SessionReplay({ sessionId }) {
                     <div className={`flex-1 min-h-0 px-6 py-6 ${panelView !== "trace" ? "hidden" : ""}`}>
                         <div className="flex h-full min-h-0 flex-col gap-4">
                             {traceStatus === "loading" && !traceEntries.length && (
-                                <div className="flex flex-1 items-center justify-center rounded-2xl border border-slate-900/60 bg-slate-900/70">
-                                    <div className="animate-pulse text-xs text-slate-400">Fetching trace data…</div>
+                                <div className="flex flex-1 items-center justify-center rounded-2xl border border-slate-800/60 bg-slate-900/65">
+                                    <div className="animate-pulse text-xs text-slate-300">Fetching trace data…</div>
                                 </div>
                             )}
                             {traceStatus === "error" && !traceEntries.length && (
-                                <div className="rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-xs text-rose-200">
+                                <div className="rounded-2xl border border-rose-500/40 bg-rose-500/15 px-4 py-3 text-xs text-rose-100">
                                     Unable to load traces for this session.
                                 </div>
                             )}
                             {traceStatus === "ready" && !traceEntries.length && (
-                                <div className="rounded-2xl border border-slate-900/60 bg-slate-900/70 px-4 py-3 text-xs text-slate-400">
+                                <div className="rounded-2xl border border-slate-800/60 bg-slate-900/60 px-4 py-3 text-xs text-slate-300">
                                     No function traces were captured for this session.
                                 </div>
                             )}
                             {traceStatus === "idle" && !traceEntries.length && (
-                                <div className="rounded-2xl border border-slate-900/60 bg-slate-900/70 px-4 py-3 text-xs text-slate-400">
+                                <div className="rounded-2xl border border-slate-800/60 bg-slate-900/60 px-4 py-3 text-xs text-slate-300">
                                     Traces will appear once data is collected for this session.
                                 </div>
                             )}
@@ -1114,15 +1137,15 @@ export default function SessionReplay({ sessionId }) {
                                                         className={`w-full rounded-xl border px-4 py-3 text-left text-xs transition focus:outline-none focus:ring-2 focus:ring-sky-500 ${
                                                             isActive
                                                                 ? "border-sky-500/60 bg-sky-500/10 text-slate-100"
-                                                                : "border-slate-800/60 bg-slate-950/40 text-slate-300 hover:border-slate-700 hover:bg-slate-900/60"
+                                                                : "border-slate-700/60 bg-slate-900/45 text-slate-200 hover:border-slate-600 hover:bg-slate-900/65"
                                                         }`}
                                                     >
-                                                        <div className="font-mono text-[11px] text-slate-400">{entry.label}</div>
-                                                        <div className="mt-2 flex items-center justify-between text-[11px] uppercase tracking-[0.25em] text-slate-500">
+                                                        <div className="font-mono text-[11px] text-slate-300">{entry.label}</div>
+                                                        <div className="mt-2 flex items-center justify-between text-[11px] uppercase tracking-[0.25em] text-slate-300">
                                                             <span>Status {meta.status ?? "—"}</span>
                                                             <span>{meta.durMs != null ? `${meta.durMs}ms` : "—"}</span>
                                                         </div>
-                                                        <div className="mt-1 text-[10px] uppercase tracking-[0.3em] text-slate-500">
+                                                        <div className="mt-1 text-[10px] uppercase tracking-[0.3em] text-slate-300">
                                                             {entry.total} events
                                                         </div>
                                                     </button>
@@ -1130,7 +1153,7 @@ export default function SessionReplay({ sessionId }) {
                                             })}
                                         </div>
                                     </div>
-                                    <div className="min-h-0 flex-1 overflow-hidden rounded-2xl border border-slate-900/70 bg-slate-950/80 p-4">
+                                    <div className="min-h-0 flex-1 overflow-hidden rounded-2xl border border-slate-800/60 bg-slate-900/75 p-4">
                                         <FunctionTraceViewer trace={selectedTrace?.events || []} title={traceTitle} className="is-embedded" />
                                     </div>
                                 </div>

--- a/src/pages/SessionReplay.jsx
+++ b/src/pages/SessionReplay.jsx
@@ -1236,13 +1236,13 @@ export default function SessionReplay({ sessionId }) {
     );
 
     const traceFullView = (
-        <section className="flex min-h-0 flex-1 flex-col border-t border-slate-200 bg-white">
+        <section className="flex min-h-0 flex-1 flex-col overflow-hidden border-t border-slate-200 bg-white">
             {tracePanelContent}
         </section>
     );
 
     return (
-        <div className="flex min-h-screen min-w-0 flex-col overflow-x-hidden bg-slate-100 text-slate-900">
+        <div className="flex h-screen min-w-0 flex-col overflow-hidden bg-slate-100 text-slate-900">
             <header className="border-b border-slate-200 bg-white px-8 py-5">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                     <div className="flex items-center gap-4">
@@ -1282,18 +1282,18 @@ export default function SessionReplay({ sessionId }) {
                     <span>{viewMode === "replay" ? timelineSummaryText : traceSummaryText}</span>
                 </div>
             </header>
-            <main className="flex flex-1 min-h-0 min-w-0 flex-col overflow-x-hidden">
+            <main className="flex flex-1 min-h-0 min-w-0 flex-col overflow-hidden">
                 {viewMode === "replay" ? (
                     <div className="flex flex-1 min-h-0 flex-col lg:flex-row">
                         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
                             {playbackSection}
                         </div>
-                        <div className="flex min-h-0 min-w-0 flex-1 flex-col lg:w-[26rem] lg:flex-none lg:shrink-0 xl:w-[30rem]">
+                        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden lg:w-[26rem] lg:flex-none lg:shrink-0 xl:w-[30rem]">
                             {timelinePanel}
                         </div>
                     </div>
                 ) : (
-                    <div className="flex flex-1 min-h-0 flex-col">
+                    <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
                         {traceFullView}
                     </div>
                 )}


### PR DESCRIPTION
## Summary
- replace the app shell with a single-screen experience and refreshed landing state for missing session ids
- add a session traces hook and reuse it for the function trace page and the new inspector tab
- embed a trace viewer panel alongside the session replay timeline with styling updates and function trace controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f53d44247083278b2231fbd96bf575